### PR TITLE
Automation of generating project docs and demos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ and published to `npm` independently.
 
 ## The Libraries
 ### sw-appcache-behavior
-A service worker fetch handler that mimics the behavior defined in a page&#x27;s App Cache manifest.
+A service worker implementation of the behavior defined in a page&#x27;s App Cache manifest.
 
 **Install**: `npm install --save-dev sw-appcache-behavior`
 
-**Learn More**: [About](projects/sw-appcache-behavior#about) •
-                [Usage](projects/sw-appcache-behavior#usage) •
+**Learn More**: [About](projects/sw-appcache-behavior) •
+                [Demo](projects/sw-appcache-behavior#demo) •
                 [API](projects/sw-appcache-behavior#api)
 
 

--- a/projects/sw-appcache-behavior/README.md
+++ b/projects/sw-appcache-behavior/README.md
@@ -1,1 +1,70 @@
-Docs to come.
+# sw-appcache-behavior
+
+A service worker implementation of the behavior defined in a page's App Cache manifest.
+
+## Installation
+
+`npm install --save-dev sw-appcache-behavior`
+
+## Demo
+
+Browse sample source code in the [demo directory](demo/), or
+[try it out](https://googlechrome.github.io/sw-helpers/sw-appcache-behavior/demo/) directly.
+
+## API
+
+### goog.legacyAppCacheBehavior
+
+[projects/sw-appcache-behavior/src/appcache-behavior-import.js:493-506](https://github.com/GoogleChrome/sw-helpers/blob/a97d1aaafaaa6829255a525a5f6cb0b4c811e045/projects/sw-appcache-behavior/src/appcache-behavior-import.js#L493-L506 "Source code on GitHub")
+
+`goog.legacyAppCacheBehavior` is the main entry point to the library
+from within service worker code.
+
+**Important**
+In addition to calling `goog.legacyAppCacheBehavior` from within your
+service worker, you _must_ add the following to each HTML document that
+contains an App Cache Manifest:
+
+```html
+<script src="path/to/client-runtime.js"
+        data-service-worker="service-worker.js">
+</script>
+```
+
+(The `data-service-worker` attribute is optional. If provided, it will
+automatically call
+[`navigator.serviceWorker.register()`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register)
+for you.)
+
+Once you've added `<script src="path/to/client-runtime.js"></script>` to
+your HTML pages, you can use `goog.legacyAppCacheBehavior` within your
+service worker script to get a Response`suitable for passing to
+[`FetchEvent.respondWidth()\`](<https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith>):
+
+```js
+self.addEventListener('fetch', event => {
+  event.respondWith(goog.legacyAppCacheBehavior(event).catch(error => {
+    // Fallback behavior goes here, e.g. return fetch(event.request);
+  }));
+});
+```
+
+`goog.legacyAppCacheBehavior` can be selectively applied to only a subset
+of requests, to aid in the migration off of App Cache and onto a more
+robust service worker implementation:
+
+```js
+self.addEventListener('fetch', event => {
+  if (event.request.url.match(/legacyRegex/)) {
+    event.respondWith(goog.legacyAppCacheBehavior(event));
+  } else {
+    event.respondWith(robustServiceWorkerBehavior(event));
+  }
+});
+```
+
+**Parameters**
+
+-   `event` **FetchEvent** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).&lt;[Response](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5)>** 

--- a/projects/sw-appcache-behavior/README.md
+++ b/projects/sw-appcache-behavior/README.md
@@ -15,7 +15,7 @@ Browse sample source code in the [demo directory](demo/), or
 
 ### goog.legacyAppCacheBehavior
 
-[projects/sw-appcache-behavior/src/appcache-behavior-import.js:501-514](https://github.com/GoogleChrome/sw-helpers/blob/931219008dad0d53d5cc0a630680b104d7bdc2ff/projects/sw-appcache-behavior/src/appcache-behavior-import.js#L501-L514 "Source code on GitHub")
+[projects/sw-appcache-behavior/src/appcache-behavior-import.js:501-514](https://github.com/GoogleChrome/sw-helpers/blob/a263acc564fb00bda1ba770327da49d6c31ceed8/projects/sw-appcache-behavior/src/appcache-behavior-import.js#L501-L514 "Source code on GitHub")
 
 `goog.legacyAppCacheBehavior` is the main entry point to the library
 from within service worker code.
@@ -38,8 +38,8 @@ for you.)
 
 Once you've added `<script src="path/to/client-runtime.js"></script>` to
 your HTML pages, you can use `goog.legacyAppCacheBehavior` within your
-service worker script to get a Response`suitable for passing to
-[`FetchEvent.respondWidth()\`](<https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith>):
+service worker script to get a `Response` suitable for passing to
+[`FetchEvent.respondWidth()`](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith):
 
 ```js
 // Import the library into the service worker global scope:

--- a/projects/sw-appcache-behavior/README.md
+++ b/projects/sw-appcache-behavior/README.md
@@ -15,7 +15,7 @@ Browse sample source code in the [demo directory](demo/), or
 
 ### goog.legacyAppCacheBehavior
 
-[projects/sw-appcache-behavior/src/appcache-behavior-import.js:493-506](https://github.com/GoogleChrome/sw-helpers/blob/a97d1aaafaaa6829255a525a5f6cb0b4c811e045/projects/sw-appcache-behavior/src/appcache-behavior-import.js#L493-L506 "Source code on GitHub")
+[projects/sw-appcache-behavior/src/appcache-behavior-import.js:501-514](https://github.com/GoogleChrome/sw-helpers/blob/931219008dad0d53d5cc0a630680b104d7bdc2ff/projects/sw-appcache-behavior/src/appcache-behavior-import.js#L501-L514 "Source code on GitHub")
 
 `goog.legacyAppCacheBehavior` is the main entry point to the library
 from within service worker code.
@@ -42,6 +42,10 @@ service worker script to get a Response`suitable for passing to
 [`FetchEvent.respondWidth()\`](<https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith>):
 
 ```js
+// Import the library into the service worker global scope:
+// https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
+importScripts('path/to/appcache-behavior-import.js');
+
 self.addEventListener('fetch', event => {
   event.respondWith(goog.legacyAppCacheBehavior(event).catch(error => {
     // Fallback behavior goes here, e.g. return fetch(event.request);
@@ -54,6 +58,10 @@ of requests, to aid in the migration off of App Cache and onto a more
 robust service worker implementation:
 
 ```js
+// Import the library into the service worker global scope:
+// https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
+importScripts('path/to/appcache-behavior-import.js');
+
 self.addEventListener('fetch', event => {
   if (event.request.url.match(/legacyRegex/)) {
     event.respondWith(goog.legacyAppCacheBehavior(event));

--- a/projects/sw-appcache-behavior/package.json
+++ b/projects/sw-appcache-behavior/package.json
@@ -1,14 +1,14 @@
 {
   "name": "sw-appcache-behavior",
   "version": "0.0.1",
-  "private": true,
-  "description": "A service worker fetch handler that mimics the behavior defined in a page's App Cache manifest.",
+  "description": "A service worker implementation of the behavior defined in a page's App Cache manifest.",
   "keywords": [
     "appcache",
     "service worker",
     "sw",
     "offline",
-    "manifest"
+    "manifest",
+    "app cache"
   ],
   "author": {
     "name": "Jeff Posnick",

--- a/projects/sw-appcache-behavior/src/appcache-behavior-import.js
+++ b/projects/sw-appcache-behavior/src/appcache-behavior-import.js
@@ -440,27 +440,53 @@
   }
 
   /**
-   * The main entry point into the library.
-   * It is meant to be called by a service worker's `fetch` event handler:
+   * `goog.legacyAppCacheBehavior` is the main entry point to the library
+   * from within service worker code.
    *
-   *     self.addEventListener('fetch', event => {
-   *       event.respondWith(goog.legacyAppCacheBehavior(event).catch(error => {
-   *         // Fallback behavior goes here, e.g. return fetch(event.request);
-   *       }));
-   *     });
+   * **Important**
+   * In addition to calling `goog.legacyAppCacheBehavior` from within your
+   * service worker, you *must* add the following to each HTML document that
+   * contains an App Cache Manifest:
    *
-   * `goog.legacyAppCacheBehavior()` can be selectively applied to only a subset
+   * ```html
+   * <script src="path/to/client-runtime.js"
+   *         data-service-worker="service-worker.js">
+   * </script>
+   * ```
+   *
+   * (The `data-service-worker` attribute is optional. If provided, it will
+   * automatically call
+   * [`navigator.serviceWorker.register()`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register)
+   * for you.)
+   *
+   * Once you've added `<script src="path/to/client-runtime.js"></script>` to
+   * your HTML pages, you can use `goog.legacyAppCacheBehavior` within your
+   * service worker script to get a Response` suitable for passing to
+   * [`FetchEvent.respondWidth()`](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith):
+   *
+   * ```js
+   * self.addEventListener('fetch', event => {
+   *   event.respondWith(goog.legacyAppCacheBehavior(event).catch(error => {
+   *     // Fallback behavior goes here, e.g. return fetch(event.request);
+   *   }));
+   * });
+   * ```
+   *
+   * `goog.legacyAppCacheBehavior` can be selectively applied to only a subset
    * of requests, to aid in the migration off of App Cache and onto a more
    * robust service worker implementation:
    *
-   *     self.addEventListener('fetch', event => {
-   *       if (event.request.url.match(/legacyRegex/)) {
-   *         event.respondWith(goog.legacyAppCacheBehavior(event));
-   *       } else {
-   *         event.respondWith(robustServiceWorkerBehavior(event));
-   *       }
-   *     });
+   * ```js
+   * self.addEventListener('fetch', event => {
+   *   if (event.request.url.match(/legacyRegex/)) {
+   *     event.respondWith(goog.legacyAppCacheBehavior(event));
+   *   } else {
+   *     event.respondWith(robustServiceWorkerBehavior(event));
+   *   }
+   * });
+   * ```
    *
+   * @alias goog.legacyAppCacheBehavior
    * @param {FetchEvent} event
    * @returns {Promise.<Response>}
    */

--- a/projects/sw-appcache-behavior/src/appcache-behavior-import.js
+++ b/projects/sw-appcache-behavior/src/appcache-behavior-import.js
@@ -461,7 +461,7 @@
    *
    * Once you've added `<script src="path/to/client-runtime.js"></script>` to
    * your HTML pages, you can use `goog.legacyAppCacheBehavior` within your
-   * service worker script to get a Response` suitable for passing to
+   * service worker script to get a `Response` suitable for passing to
    * [`FetchEvent.respondWidth()`](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith):
    *
    * ```js
@@ -484,7 +484,7 @@
    * // Import the library into the service worker global scope:
    * // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
    * importScripts('path/to/appcache-behavior-import.js');
-   * 
+   *
    * self.addEventListener('fetch', event => {
    *   if (event.request.url.match(/legacyRegex/)) {
    *     event.respondWith(goog.legacyAppCacheBehavior(event));

--- a/projects/sw-appcache-behavior/src/appcache-behavior-import.js
+++ b/projects/sw-appcache-behavior/src/appcache-behavior-import.js
@@ -465,6 +465,10 @@
    * [`FetchEvent.respondWidth()`](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/respondWith):
    *
    * ```js
+   * // Import the library into the service worker global scope:
+   * // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
+   * importScripts('path/to/appcache-behavior-import.js');
+   *
    * self.addEventListener('fetch', event => {
    *   event.respondWith(goog.legacyAppCacheBehavior(event).catch(error => {
    *     // Fallback behavior goes here, e.g. return fetch(event.request);
@@ -477,6 +481,10 @@
    * robust service worker implementation:
    *
    * ```js
+   * // Import the library into the service worker global scope:
+   * // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
+   * importScripts('path/to/appcache-behavior-import.js');
+   * 
    * self.addEventListener('fetch', event => {
    *   if (event.request.url.match(/legacyRegex/)) {
    *     event.respondWith(goog.legacyAppCacheBehavior(event));

--- a/templates/Project-README.hbs
+++ b/templates/Project-README.hbs
@@ -1,0 +1,13 @@
+# {{name}}
+
+{{description}}
+
+## Installation
+`npm install --save-dev {{name}}`
+
+## Demo
+
+Browse sample source code in the [demo directory](demo/), or
+[try it out](https://googlechrome.github.io/sw-helpers/{{name}}/demo/) directly.
+
+## API

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -1,5 +1,7 @@
 <!-- To make changes, edit templates/README.hbs, not README.md! -->
-[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-url]][daviddm-image]
+[![NPM version][npm-image]][npm-url]
+[![Build Status][travis-image]][travis-url]
+[![devDependency Status](https://david-dm.org/googlechrome/sw-helpers/dev-status.svg)](https://david-dm.org/googlechrome/sw-helpers#info=devDependencies)
 
 # Service Worker Helpers
 
@@ -18,8 +20,8 @@ and published to `npm` independently.
 
 **Install**: `npm install --save-dev {{name}}`
 
-**Learn More**: [About](projects/{{name}}#about) •
-                [Usage](projects/{{name}}#usage) •
+**Learn More**: [About](projects/{{name}}) •
+                [Demo](projects/{{name}}#demo) •
                 [API](projects/{{name}}#api)
 
 {{/each}}
@@ -82,5 +84,3 @@ limitations under the License.
 [npm-image]: https://badge.fury.io/js/sw-helpers.svg
 [travis-url]: https://travis-ci.org/GoogleChrome/sw-helpers
 [travis-image]: https://travis-ci.org/GoogleChrome/sw-helpers.svg?branch=master
-[daviddm-url]: https://david-dm.org/googlechrome/sw-helpers.svg?theme=shields.io
-[daviddm-image]: https://david-dm.org/googlechrome/sw-helpers


### PR DESCRIPTION
R: @addyosmani @wibblymat @gauntface

Fixes #12

This adds some additional automation of documentation, via the `documentation:repo` and `documentation:projects` tasks, along with some updates to the Handlebars templates.

It also pushes out the `demo` and `build` directories for each project to `gh-pages`, to ensure that we have a live demo to point folks to from the docs.

The `sw-appcache-behavior` documentation is also included in this PR.