### PR TITLE
Cache bust manifest request when the response is > 24 hours old.

### DIFF
--- a/projects/sw-appcache-behavior/README.md
+++ b/projects/sw-appcache-behavior/README.md
@@ -20,6 +20,13 @@ Browse sample source code in the [demo directory](https://github.com/GoogleChrom
 `goog.legacyAppCacheBehavior` is the main entry point to the library
 from within service worker code.
 
+The goal of the library is to provide equivalent behavior to AppCache whenever
+possible. The one difference in how this library behaves compared to a native
+AppCache implementation is that its client-side code will attempt to fetch
+a fresh AppCache manifest once any cached version is older than 24 hours. This
+works around a [major pitfall](http://alistapart.com/article/application-cache-is-a-douchebag#section6)
+in the native AppCache implementation.
+
 **Important**
 In addition to calling `goog.legacyAppCacheBehavior` from within your
 service worker, you _must_ add the following to each HTML document that

--- a/projects/sw-appcache-behavior/package.json
+++ b/projects/sw-appcache-behavior/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sw-appcache-behavior",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A service worker implementation of the behavior defined in a page's App Cache manifest.",
   "keywords": [
     "appcache",

--- a/projects/sw-appcache-behavior/src/client-runtime.js
+++ b/projects/sw-appcache-behavior/src/client-runtime.js
@@ -144,7 +144,6 @@ function checkManifestVersion(db, manifestUrl) {
         var manifestAgeInMillis = Date.now() - manifestDate;
         // If the age is greater than 24 hours, then we need to refetch without
         // hitting the cache.
-        console.log(manifestAgeInMillis);
         if (manifestAgeInMillis > (24 * 60 * 60 * 1000)) {
           var noCacheRequest = new Request(manifestUrl, {
             credentials: 'include',

--- a/projects/sw-appcache-behavior/src/client-runtime.js
+++ b/projects/sw-appcache-behavior/src/client-runtime.js
@@ -136,8 +136,31 @@ function checkManifestVersion(db, manifestUrl) {
 
   return Promise.all([
     // TODO: Handle manifest fetch failure errors.
-    // TODO: Consider cache-busting if the manifest response > 24 hours old.
     fetch(manifestRequest).then(function(manifestResponse) {
+      var dateHeaderValue = manifestResponse.headers.get('date');
+      if (dateHeaderValue) {
+        var manifestDate = new Date(dateHeaderValue).valueOf();
+        // Calculate the age of the manifest in milliseconds.
+        var manifestAgeInMillis = Date.now() - manifestDate;
+        // If the age is greater than 24 hours, then we need to refetch without
+        // hitting the cache.
+        console.log(manifestAgeInMillis);
+        if (manifestAgeInMillis > (24 * 60 * 1000)) {
+          var noCacheRequest = new Request(manifestUrl, {
+            credentials: 'include',
+            // See https://fetch.spec.whatwg.org/#requestcache
+            cache: 'reload',
+            headers: {
+              'X-Use-Fetch': true
+            }
+          });
+
+          return fetch(noCacheRequest).then(function(noCacheResponse) {
+            return noCacheResponse.text();
+          });
+        }
+      }
+
       return manifestResponse.text();
     }).then(function(text) {
       var md5 = require('blueimp-md5');

--- a/projects/sw-appcache-behavior/src/client-runtime.js
+++ b/projects/sw-appcache-behavior/src/client-runtime.js
@@ -145,7 +145,7 @@ function checkManifestVersion(db, manifestUrl) {
         // If the age is greater than 24 hours, then we need to refetch without
         // hitting the cache.
         console.log(manifestAgeInMillis);
-        if (manifestAgeInMillis > (24 * 60 * 1000)) {
+        if (manifestAgeInMillis > (24 * 60 * 60 * 1000)) {
           var noCacheRequest = new Request(manifestUrl, {
             credentials: 'include',
             // See https://fetch.spec.whatwg.org/#requestcache


### PR DESCRIPTION
R: @jakearchibald @addyosmani @wibblymat @gauntface

Fixes #18 

This code checks the age of the response from the AppCache manifest request, and if it's older than 24 hours, makes another request using `cache: reload` to (ideally) bypass the cache, to work around http://alistapart.com/article/application-cache-is-a-douchebag#section6

I'm using `cache: reload` here, which unfortunately isn't universally supported in browsers right now. The alternative would be to append cache-busting URL parameters to the request, but I feel like it's in keeping with the spirit of this library to use the primitives provided by the platform. This is also an additional nice-to-have feature beyond the core functionality of the library, so if `cache: reload` doesn't have an effect, we're no worse off than we were.