### PR TITLE
gulpfile updates

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,9 +1,0 @@
-{
-  "name": "sw-testing-helpers",
-  "version": "0.0.14",
-  "dependencies": {
-    "selenium-webdriver": {
-      "version": "2.52.0"
-    }
-  }
-}


### PR DESCRIPTION
R: @addyosmani @wibblymat @gauntface

Fixes #5

This updates the `gulp test` command to ensure that failures always cause the process to exit with a non-zero error code.

It also resolves an issue that was due to the `gh-pages` module pulling in a dependency that broke the newer `selenium-webdriver` modules.