### PR TITLE
sw-offline-google-analytics initial release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <!-- To make changes, edit templates/README.hbs, not README.md! -->
-[![NPM version][npm-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
-[![devDependency Status](https://david-dm.org/googlechrome/sw-helpers/dev-status.svg)](https://david-dm.org/googlechrome/sw-helpers#info=devDependencies)
 
 # Service Worker Helpers
 
@@ -24,7 +22,7 @@ A service worker implementation of the behavior defined in a page&#x27;s App Cac
                 [API](projects/sw-appcache-behavior#api)
 
 ### sw-offline-google-analytics
-A service worker implementation of the behavior defined in a page&#x27;s App Cache manifest.
+A library to extend a service worker&#x27;s behavior, allowing it to retry failed Google Analytics requests.
 
 **Install**: `npm install --save-dev sw-offline-google-analytics`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A service worker implementation of the behavior defined in a page&#x27;s App Cac
                 [API](projects/sw-appcache-behavior#api)
 
 ### sw-offline-google-analytics
-A library to extend a service worker&#x27;s behavior, allowing it to retry failed Google Analytics requests.
+A service worker helper library to retry offline Google Analytics requests when a connection is available.
 
 **Install**: `npm install --save-dev sw-offline-google-analytics`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ A service worker implementation of the behavior defined in a page&#x27;s App Cac
                 [Demo](projects/sw-appcache-behavior#demo) •
                 [API](projects/sw-appcache-behavior#api)
 
+### sw-offline-google-analytics
+A service worker implementation of the behavior defined in a page&#x27;s App Cache manifest.
+
+**Install**: `npm install --save-dev sw-offline-google-analytics`
+
+**Learn More**: [About](projects/sw-offline-google-analytics) •
+                [Demo](projects/sw-offline-google-analytics#demo) •
+                [API](projects/sw-offline-google-analytics#api)
+
 
 ## Development
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -45,7 +45,7 @@ npmPath.setSync();
  */
 const lintPackage = project => {
   return new Promise((resolve, reject) => {
-    gulp.src([`${project}/**/*.js`, `!${project}/build/**`])
+    gulp.src([`${project}/**/*.js`, `!${project}/**/build/**`])
       .pipe(eslint())
       .pipe(eslint.format())
       .pipe(eslint.results(results => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -93,7 +93,8 @@ const documentPackage = project => {
     gulp.src('templates/Project-README.hbs')
       .pipe(handlebars({
         name: projectMetadata.name,
-        description: projectMetadata.description
+        description: projectMetadata.description,
+        background: projectMetadata.background
       }))
       .pipe(rename('README.md'))
       .pipe(gulp.dest(project))
@@ -132,6 +133,7 @@ gulp.task('build', () => {
 
 gulp.task('build:watch', unusedCallback => {
   gulp.watch(`projects/${projectOrStar}/src/**/*`, ['build']);
+  gulp.watch(`lib/**/*`, ['build']);
 });
 
 gulp.task('serve', unusedCallback => {

--- a/lib/browserify-tests.js
+++ b/lib/browserify-tests.js
@@ -1,0 +1,40 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import browserify from 'browserify';
+import del from 'del';
+import fs from 'fs';
+import glob from 'glob';
+import path from 'path';
+
+module.exports = directory => {
+  const build = `${directory}/build`;
+  return del(`${directory}/build`).then(() => {
+    fs.mkdirSync(build);
+    const files = glob.sync(`${directory}/*.js`);
+
+    return Promise.all(files.map(file => {
+      return new Promise((resolve, reject) => {
+        const bundler = browserify(file);
+
+        bundler.bundle()
+          .pipe(fs.createWriteStream(path.join(build, path.basename(file))))
+          .on('error', reject)
+          .on('finish', resolve);
+      });
+    }));
+  });
+};
+

--- a/lib/idb-helper.js
+++ b/lib/idb-helper.js
@@ -99,9 +99,9 @@ IDBHelper.prototype.delete = function(key) {
  */
 IDBHelper.prototype.get = function(key) {
   return this._getDb().then(db => {
-    const tx = db.transaction(this._storeName);
-    const objectStore = tx.objectStore(this._storeName);
-    return objectStore.get(key);
+    return db.transaction(this._storeName)
+      .objectStore(this._storeName)
+      .get(key);
   });
 };
 
@@ -115,9 +115,9 @@ IDBHelper.prototype.get = function(key) {
  */
 IDBHelper.prototype.getAllValues = function() {
   return this._getDb().then(db => {
-    const tx = db.transaction(this._storeName);
-    const objectStore = tx.objectStore(this._storeName);
-    return objectStore.getAll();
+    return db.transaction(this._storeName)
+      .objectStore(this._storeName)
+      .getAll();
   });
 };
 
@@ -132,9 +132,9 @@ IDBHelper.prototype.getAllValues = function() {
  */
 IDBHelper.prototype.getAllKeys = function() {
   return this._getDb().then(db => {
-    const tx = db.transaction(this._storeName);
-    const objectStore = tx.objectStore(this._storeName);
-    return objectStore.getAllKeys();
+    return db.transaction(this._storeName)
+      .objectStore(this._storeName)
+      .getAllKeys();
   });
 };
 

--- a/lib/idb-helper.js
+++ b/lib/idb-helper.js
@@ -1,0 +1,141 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+const idb = require('idb');
+
+/**
+ * A wrapper to store for an IDB connection to a particular ObjectStore.
+ *
+ * @private
+ * @class
+ */
+function IDBHelper(name, version, storeName) {
+  if (name == undefined || version == undefined || storeName == undefined) {
+    throw Error('name, version, storeName must be passed to the constructor.');
+  }
+
+  this._name = name;
+  this._version = version;
+  this._storeName = storeName;
+}
+
+/**
+ * Returns a promise that resolves with an open connection to IndexedDB, either
+ * existing or newly opened.
+ *
+ * @private
+ * @returns {Promise.<DB>}
+ */
+IDBHelper.prototype._getDb = function() {
+  if (this._db) {
+    return Promise.resolve(this._db);
+  }
+
+  return idb.open(this._name, this._version, upgradeDB => {
+    upgradeDB.createObjectStore(this._storeName);
+  }).then(db => {
+    this._db = db;
+    return db;
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies saving the key/value
+ * pair to the object store.
+ * Returns a Promise that fulfills when the transaction completes.
+ *
+ * @private
+ * @param {String} key
+ * @param {Object} value
+ * @returns {Promise.<T>}
+ */
+IDBHelper.prototype.put = function(key, value) {
+  return this._getDb().then(db => {
+    const tx = db.transaction(this._storeName, 'readwrite');
+    const objectStore = tx.objectStore(this._storeName);
+    objectStore.put(value, key);
+    return tx.complete;
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies deleting an entry
+ * from the object store.
+ * Returns a Promise that fulfills when the transaction completes.
+ *
+ * @private
+ * @param {String} key
+ * @returns {Promise.<T>}
+ */
+IDBHelper.prototype.delete = function(key) {
+  return this._getDb().then(db => {
+    const tx = db.transaction(this._storeName, 'readwrite');
+    const objectStore = tx.objectStore(this._storeName);
+    objectStore.delete(key);
+    return tx.complete;
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies getting a key's value
+ * from the object store.
+ * Returns a promise that fulfills with the value.
+ *
+ * @private
+ * @param {String} key
+ * @returns {Promise.<Object>}
+ */
+IDBHelper.prototype.get = function(key) {
+  return this._getDb().then(db => {
+    const tx = db.transaction(this._storeName);
+    const objectStore = tx.objectStore(this._storeName);
+    return objectStore.get(key);
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies getting all the values
+ * in an object store.
+ * Returns a promise that fulfills with all the values.
+ *
+ * @private
+ * @returns {Promise.<Array.<Object>>}
+ */
+IDBHelper.prototype.getAllValues = function() {
+  return this._getDb().then(db => {
+    const tx = db.transaction(this._storeName);
+    const objectStore = tx.objectStore(this._storeName);
+    return objectStore.getAll();
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies getting all the keys
+ * in an object store.
+ * Returns a promise that fulfills with all the keys.
+ *
+ * @private
+ * @param {String} storeName
+ * @returns {Promise.<Array.<Object>>}
+ */
+IDBHelper.prototype.getAllKeys = function() {
+  return this._getDb().then(db => {
+    const tx = db.transaction(this._storeName);
+    const objectStore = tx.objectStore(this._storeName);
+    return objectStore.getAllKeys();
+  });
+};
+
+module.exports = IDBHelper;

--- a/lib/log.js
+++ b/lib/log.js
@@ -13,18 +13,11 @@
  limitations under the License.
 */
 
-import browserify from 'browserify';
-import fs from 'fs';
-import path from 'path';
-
 module.exports = () => {
-  var file = 'offline-google-analytics-import.js';
-  return new Promise((resolve, reject) => {
-    const bundler = browserify(path.join(__dirname, 'src', file));
-
-    bundler.bundle()
-      .pipe(fs.createWriteStream(path.join(__dirname, 'build', file)))
-      .on('error', reject)
-      .on('finish', resolve);
-  });
+  // Evaluate goog.DEBUG at runtime rather than once at export time to allow
+  // developers to enable logging "on-the-fly" by setting `goog.DEBUG = true`
+  // in the JavaScript console.
+  return (self && self.goog && self.goog.DEBUG) ?
+    console.debug.bind(console) :
+    function() {};
 };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -13,18 +13,9 @@
  limitations under the License.
 */
 
-import browserify from 'browserify';
-import fs from 'fs';
-import path from 'path';
+const namespace = 'goog';
 
-module.exports = () => {
-  var file = 'offline-google-analytics-import.js';
-  return new Promise((resolve, reject) => {
-    const bundler = browserify(path.join(__dirname, 'src', file));
-
-    bundler.bundle()
-      .pipe(fs.createWriteStream(path.join(__dirname, 'build', file)))
-      .on('error', reject)
-      .on('finish', resolve);
-  });
+module.exports = (name, func) => {
+  self[namespace] = self[namespace] || {};
+  self[namespace][name] = func;
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,9 +1,0 @@
-{
-  "name": "sw-testing-helpers",
-  "version": "0.0.14",
-  "dependencies": {
-    "selenium-webdriver": {
-      "version": "2.52.0"
-    }
-  }
-}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/GoogleChrome/sw-helpers#readme",
   "devDependencies": {
     "babel": "^6.5.2",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "blueimp-md5": "^2.3.0",
     "browserify": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^2.8.0",
     "eslint-config-google": "^0.5.0",
     "express": "^4.13.4",
+    "fetch-mock": "^5.0.0",
     "fs-extra": "^0.30.0",
     "gh-pages": "^0.11.0",
     "glob": "^7.0.3",

--- a/projects/sw-offline-google-analytics/README.md
+++ b/projects/sw-offline-google-analytics/README.md
@@ -1,6 +1,6 @@
 # sw-offline-google-analytics
 
-A service worker implementation of the behavior defined in a page's App Cache manifest.
+A library to extend a service worker's behavior, allowing it to retry failed Google Analytics requests.
 
 ## Installation
 
@@ -15,20 +15,24 @@ Browse sample source code in the [demo directory](https://github.com/GoogleChrom
 
 ### goog.useOfflineGoogleAnalytics
 
-[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:182-229](https://github.com/GoogleChrome/sw-helpers/blob/213765485d2c3378497e2a80c2b80993a7b09cdf/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L182-L229 "Source code on GitHub")
+[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:45-83](https://github.com/GoogleChrome/sw-helpers/blob/5320c8269f3368939bf792c4bc1a47487ca7963f/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L45-L83 "Source code on GitHub")
 
-`goog.useOfflineGoogleAnalytics` is the main entry point to the library
-from within service worker code.
+In order to use the library, call`goog.useOfflineGoogleAnalytics()`.
+It will take care of setting up service worker `fetch` handlers to ensure
+that the Google Analytics JavaScript is available offline, and that any
+Google Analytics requests made while offline are saved (using `IndexedDB`)
+and retried the next time the service worker starts up.
 
-```js
-// Inside your service worker JavaScript, ideally before any other
-// 'fetch' event handlers are defined:
+**Examples**
 
-// 1) Import the library into the service worker global scope, using
-// https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
+```javascript
+// This code should live inside your service worker JavaScript, ideally
+// before any other 'fetch' event handlers are defined:
+
+// First, import the library into the service worker global scope:
 importScripts('path/to/offline-google-analytics-import.js');
 
-// 2) Call goog.useOfflineGoogleAnalytics() to activate the library.
+// Then, call goog.useOfflineGoogleAnalytics() to activate the library.:
 goog.useOfflineGoogleAnalytics();
 
 // At this point, implement any other service worker caching strategies

--- a/projects/sw-offline-google-analytics/README.md
+++ b/projects/sw-offline-google-analytics/README.md
@@ -15,25 +15,24 @@ Browse sample source code in the [demo directory](https://github.com/GoogleChrom
 
 ### goog.useOfflineGoogleAnalytics
 
-[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:134-166](https://github.com/GoogleChrome/sw-helpers/blob/a219fc9188654420fed08c4218c09f9cbc4b6de8/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L134-L166 "Source code on GitHub")
+[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:182-229](https://github.com/GoogleChrome/sw-helpers/blob/213765485d2c3378497e2a80c2b80993a7b09cdf/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L182-L229 "Source code on GitHub")
 
 `goog.useOfflineGoogleAnalytics` is the main entry point to the library
 from within service worker code.
 
 ```js
-// Inside your service worker JavaScript file:
+// Inside your service worker JavaScript, ideally before any other
+// 'fetch' event handlers are defined:
 
-// Import the library into the service worker global scope:
+// 1) Import the library into the service worker global scope, using
 // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
 importScripts('path/to/offline-google-analytics-import.js');
 
-// Call goog.useOfflineGoogleAnalytics() to set things up.
-goog.useOfflineGoogleAnalytics()
+// 2) Call goog.useOfflineGoogleAnalytics() to activate the library.
+goog.useOfflineGoogleAnalytics();
+
+// At this point, implement any other service worker caching strategies
+// appropriate for your web app.
 ```
 
-### replayAnalyticsRequests
-
-[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:68-115](https://github.com/GoogleChrome/sw-helpers/blob/a219fc9188654420fed08c4218c09f9cbc4b6de8/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L68-L115 "Source code on GitHub")
-
-Replays all the queued requests found in IndexedDB, by calling fetch()
-with an additional qt= parameter.
+Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)** 

--- a/projects/sw-offline-google-analytics/README.md
+++ b/projects/sw-offline-google-analytics/README.md
@@ -1,6 +1,6 @@
 # sw-offline-google-analytics
 
-A library to extend a service worker's behavior, allowing it to retry failed Google Analytics requests.
+A service worker helper library to retry offline Google Analytics requests when a connection is available.
 
 ## Installation
 
@@ -15,7 +15,7 @@ Browse sample source code in the [demo directory](https://github.com/GoogleChrom
 
 ### goog.useOfflineGoogleAnalytics
 
-[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:45-83](https://github.com/GoogleChrome/sw-helpers/blob/5320c8269f3368939bf792c4bc1a47487ca7963f/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L45-L83 "Source code on GitHub")
+[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:45-83](https://github.com/GoogleChrome/sw-helpers/blob/47105b1837b0d8f5b059f3f5d470ce4deda51816/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L45-L83 "Source code on GitHub")
 
 In order to use the library, call`goog.useOfflineGoogleAnalytics()`.
 It will take care of setting up service worker `fetch` handlers to ensure

--- a/projects/sw-offline-google-analytics/README.md
+++ b/projects/sw-offline-google-analytics/README.md
@@ -13,15 +13,23 @@ Browse sample source code in the [demo directory](https://github.com/GoogleChrom
 
 ## API
 
-### goog.useOfflineGoogleAnalytics
+### goog.offlineGoogleAnalytics.initialize
 
-[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:45-83](https://github.com/GoogleChrome/sw-helpers/blob/47105b1837b0d8f5b059f3f5d470ce4deda51816/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L45-L83 "Source code on GitHub")
+[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:57-97](https://github.com/GoogleChrome/sw-helpers/blob/ad8545442f0f6238b43a84cef79b90124bd83cfd/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L57-L97 "Source code on GitHub")
 
-In order to use the library, call`goog.useOfflineGoogleAnalytics()`.
+In order to use the library, call`goog.offlineGoogleAnalytics.initialize()`.
 It will take care of setting up service worker `fetch` handlers to ensure
 that the Google Analytics JavaScript is available offline, and that any
 Google Analytics requests made while offline are saved (using `IndexedDB`)
 and retried the next time the service worker starts up.
+
+**Parameters**
+
+-   `config` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional configuration arguments.
+    -   `config.parameterOverrides` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional URL parameters, expressed
+                         as key/value pairs, to be added to replayed Google Analytics
+                         requests. This can be used to, e.g., set a custom dimension
+                         indicating that the request was replayed.
 
 **Examples**
 
@@ -32,8 +40,15 @@ and retried the next time the service worker starts up.
 // First, import the library into the service worker global scope:
 importScripts('path/to/offline-google-analytics-import.js');
 
-// Then, call goog.useOfflineGoogleAnalytics() to activate the library.:
-goog.useOfflineGoogleAnalytics();
+// Then, call goog.offlineGoogleAnalytics.initialize():
+goog.offlineGoogleAnalytics.initialize({
+  parameterOverrides: {
+    // Optionally, pass in an Object with additional parameters that will be
+    // included in each replayed request.
+    dimension1: 'Some Value',
+    dimension2: 'Some Other Value'
+  }
+});
 
 // At this point, implement any other service worker caching strategies
 // appropriate for your web app.

--- a/projects/sw-offline-google-analytics/README.md
+++ b/projects/sw-offline-google-analytics/README.md
@@ -15,7 +15,7 @@ Browse sample source code in the [demo directory](https://github.com/GoogleChrom
 
 ### goog.offlineGoogleAnalytics.initialize
 
-[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:57-97](https://github.com/GoogleChrome/sw-helpers/blob/ad8545442f0f6238b43a84cef79b90124bd83cfd/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L57-L97 "Source code on GitHub")
+[projects/sw-offline-google-analytics/src/offline-google-analytics-import.js:59-99](https://github.com/GoogleChrome/sw-helpers/blob/abc05d9a3763f5db6c6bf650e23f997c7c1eccb2/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js#L59-L99 "Source code on GitHub")
 
 In order to use the library, call`goog.offlineGoogleAnalytics.initialize()`.
 It will take care of setting up service worker `fetch` handlers to ensure
@@ -26,10 +26,11 @@ and retried the next time the service worker starts up.
 **Parameters**
 
 -   `config` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional configuration arguments.
-    -   `config.parameterOverrides` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional URL parameters, expressed
-                         as key/value pairs, to be added to replayed Google Analytics
-                         requests. This can be used to, e.g., set a custom dimension
-                         indicating that the request was replayed.
+    -   `config.parameterOverrides` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional
+                         [Measurement Protocol parameters](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters),
+                         expressed as key/value pairs, to be added to replayed Google
+                         Analytics requests. This can be used to, e.g., set a custom
+                         dimension indicating that the request was replayed.
 
 **Examples**
 
@@ -45,8 +46,9 @@ goog.offlineGoogleAnalytics.initialize({
   parameterOverrides: {
     // Optionally, pass in an Object with additional parameters that will be
     // included in each replayed request.
-    dimension1: 'Some Value',
-    dimension2: 'Some Other Value'
+    // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+    cd1: 'Some Value',
+    cd2: 'Some Other Value'
   }
 });
 

--- a/projects/sw-offline-google-analytics/demo/index.html
+++ b/projects/sw-offline-google-analytics/demo/index.html
@@ -1,0 +1,51 @@
+<html>
+  <head>
+    <title>Offline Google Analytics Demo</title>
+  </head>
+  <body>
+    <p>
+      This is a simple demo showing how you can use
+      <code>sw-offline-google-analytics</code> to queue up and resend Google
+      Analytics requests when your web app is accessed while a user is offline.
+    </p>
+    <p>
+      Try revisiting this page while offline (either by disconnecting from your
+      network, or via Chrome DevTool's offline emulation) and then clicking
+      on the button below to trigger new Google Analytics requests. The requests
+      will be queued up in IndexedDB, and then retried the next time this
+      page's service worker starts up.
+    </p>
+    <button id="send">Send GA Event</button>
+
+    <script>
+      // Set up Google Analytics.
+      (function(i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        i[r] = i[r] || function() {
+          (i[r].q = i[r].q || []).push(arguments);
+        };
+        i[r].l = 1 * new Date();
+        a = s.createElement(o);
+        m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+      })(window, document, 'script',
+        'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-REPLACE_ME-1', 'auto');
+      // The library works the same way when using the sendBeacon transport.
+      // ga('set', 'transport', 'beacon');
+      ga('send', 'pageview');
+
+      // Register our service worker.
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('service-worker.js');
+      }
+
+      // Handle button clicks by triggering Google Analytics events.
+      document.querySelector('#send').addEventListener('click', function() {
+        ga('send', 'event', 'test', 'click');
+      });
+    </script>
+  </body>
+</html>

--- a/projects/sw-offline-google-analytics/demo/service-worker.js
+++ b/projects/sw-offline-google-analytics/demo/service-worker.js
@@ -8,7 +8,13 @@ importScripts('../build/offline-google-analytics-import.js');
 // First, enable the offline Google Analytics behavior.
 // This will get "first shot" at responding to Google Analytics requests, before
 // our catch-all fetch event listener can handle it.
-goog.useOfflineGoogleAnalytics();
+goog.offlineGoogleAnalytics.initialize({
+  parameterOverrides: {
+    // Add in any additional parameters here, or omit this section to
+    // replay the Google Analytics request without additional parameters.
+    dimension1: 'My Custom Dimension Value'
+  }
+});
 
 // Use a basic network-first caching strategy as a catch-all for everything
 // other than the Google Analytics requests.

--- a/projects/sw-offline-google-analytics/demo/service-worker.js
+++ b/projects/sw-offline-google-analytics/demo/service-worker.js
@@ -22,3 +22,7 @@ self.addEventListener('fetch', event => {
     })
   );
 });
+
+// Have the service worker take control as soon as possible.
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());

--- a/projects/sw-offline-google-analytics/demo/service-worker.js
+++ b/projects/sw-offline-google-analytics/demo/service-worker.js
@@ -12,7 +12,8 @@ goog.offlineGoogleAnalytics.initialize({
   parameterOverrides: {
     // Add in any additional parameters here, or omit this section to
     // replay the Google Analytics request without additional parameters.
-    dimension1: 'My Custom Dimension Value'
+    // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+    cd1: 'My Custom Dimension Value'
   }
 });
 

--- a/projects/sw-offline-google-analytics/demo/service-worker.js
+++ b/projects/sw-offline-google-analytics/demo/service-worker.js
@@ -1,0 +1,24 @@
+/* eslint-env worker, serviceworker */
+/* global goog */
+
+const CACHE_NAME = 'runtime-caching';
+self.goog = {DEBUG: true};
+importScripts('../build/offline-google-analytics-import.js');
+
+// First, enable the offline Google Analytics behavior.
+// This will get "first shot" at responding to Google Analytics requests, before
+// our catch-all fetch event listener can handle it.
+goog.useOfflineGoogleAnalytics();
+
+// Use a basic network-first caching strategy as a catch-all for everything
+// other than the Google Analytics requests.
+// (In a real app, you'd want to use a more sophisticated caching technique.)
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.open(CACHE_NAME).then(cache => {
+      return fetch(event.request).then(response => {
+        return cache.put(event.request, response.clone()).then(() => response);
+      }).catch(() => cache.match(event.request));
+    })
+  );
+});

--- a/projects/sw-offline-google-analytics/package.json
+++ b/projects/sw-offline-google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sw-offline-google-analytics",
   "version": "1.0.0",
-  "description": "A service worker implementation of the behavior defined in a page's App Cache manifest.",
+  "description": "A library to extend a service worker's behavior, allowing it to retry failed Google Analytics requests.",
   "keywords": [
     "service worker",
     "sw",

--- a/projects/sw-offline-google-analytics/package.json
+++ b/projects/sw-offline-google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sw-offline-google-analytics",
   "version": "1.0.0",
-  "description": "A library to extend a service worker's behavior, allowing it to retry failed Google Analytics requests.",
+  "description": "A service worker helper library to retry offline Google Analytics requests when a connection is available.",
   "keywords": [
     "service worker",
     "sw",

--- a/projects/sw-offline-google-analytics/package.json
+++ b/projects/sw-offline-google-analytics/package.json
@@ -13,7 +13,6 @@
     "email": "jeffy@google.com",
     "url": "https://jeffy.info"
   },
-  "main": "build/offline-google-analytics.js",
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",

--- a/projects/sw-offline-google-analytics/src/lib/constants.js
+++ b/projects/sw-offline-google-analytics/src/lib/constants.js
@@ -13,18 +13,18 @@
  limitations under the License.
 */
 
-import browserify from 'browserify';
-import fs from 'fs';
-import path from 'path';
-
-module.exports = () => {
-  var file = 'offline-google-analytics-import.js';
-  return new Promise((resolve, reject) => {
-    const bundler = browserify(path.join(__dirname, 'src', file));
-
-    bundler.bundle()
-      .pipe(fs.createWriteStream(path.join(__dirname, 'build', file)))
-      .on('error', reject)
-      .on('finish', resolve);
-  });
+module.exports = {
+  CACHE_NAME: 'offline-google-analytics',
+  IDB: {
+    NAME: 'offline-google-analytics',
+    STORE: 'urls',
+    VERSION: 1
+  },
+  MAX_ANALYTICS_BATCH_SIZE: 20,
+  STOP_RETRYING_AFTER: 86400000, // One day, in milliseconds.
+  URL: {
+    ANALYTICS_JS_PATH: '/analytics.js',
+    COLLECT_PATH: '/collect',
+    HOST: 'www.google-analytics.com'
+  }
 };

--- a/projects/sw-offline-google-analytics/src/lib/enqueue-request.js
+++ b/projects/sw-offline-google-analytics/src/lib/enqueue-request.js
@@ -18,6 +18,7 @@ const constants = require('./constants.js');
 
 const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
   constants.IDB.STORE);
+self.a = idbHelper;
 
 /**
  * Adds a URL to IndexedDB, along with the current timestamp.
@@ -25,11 +26,14 @@ const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
  * If the request has a body, that body will be used as the URL's search
  * parameters when saving the URL to IndexedDB.
  *
+ * If no `time` parameter is provided, Date.now() will be used.
+ *
  * @private
  * @param {Request} request
+*  @param {Number} [time]
  * @returns {Promise.<T>} A promise that resolves when IndexedDB is updated.
  */
-module.exports = request => {
+module.exports = (request, time) => {
   const url = new URL(request.url);
   return request.text().then(body => {
     // If there's a request body, then use it as the URL's search value.
@@ -39,6 +43,6 @@ module.exports = request => {
       url.search = body;
     }
 
-    return idbHelper.put(url.toString(), Date.now());
+    return idbHelper.put(url.toString(), time || Date.now());
   });
 };

--- a/projects/sw-offline-google-analytics/src/lib/enqueue-request.js
+++ b/projects/sw-offline-google-analytics/src/lib/enqueue-request.js
@@ -1,0 +1,44 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env worker, serviceworker */
+
+const IDBHelper = require('../../../../lib/idb-helper.js');
+const constants = require('./constants.js');
+
+const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+  constants.IDB.STORE);
+
+/**
+ * Adds a URL to IndexedDB, along with the current timestamp.
+ *
+ * If the request has a body, that body will be used as the URL's search
+ * parameters when saving the URL to IndexedDB.
+ *
+ * @private
+ * @param {Request} request
+ * @returns {Promise.<T>} A promise that resolves when IndexedDB is updated.
+ */
+module.exports = request => {
+  const url = new URL(request.url);
+  return request.text().then(body => {
+    // If there's a request body, then use it as the URL's search value.
+    // This is most likely because the original request was an HTTP POST
+    // that uses the beacon transport.
+    if (body) {
+      url.search = body;
+    }
+
+    return idbHelper.put(url.toString(), Date.now());
+  });
+};

--- a/projects/sw-offline-google-analytics/src/lib/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/src/lib/replay-queued-requests.js
@@ -32,7 +32,9 @@ module.exports = () => {
   return idbHelper.getAllKeys().then(urls => {
     return Promise.all(urls.map(url => {
       return idbHelper.get(url).then(queuedTime => {
-        return fetch(`${url}&qt=${queuedTime}`).catch(error => {
+        const newUrl = new URL(url);
+        newUrl.search += (newUrl.search ? '&' : '') + 'qt=' + queuedTime;
+        return fetch(newUrl.toString()).catch(error => {
           // If this was queued recently, then rethrow the error, to prevent
           // the entry from being deleted. It will be retried again later.
           if ((Date.now() - queuedTime) < constants.STOP_RETRYING_AFTER) {

--- a/projects/sw-offline-google-analytics/src/lib/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/src/lib/replay-queued-requests.js
@@ -1,0 +1,45 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env worker, serviceworker */
+
+const IDBHelper = require('../../../../lib/idb-helper.js');
+const constants = require('./constants.js');
+
+const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+  constants.IDB.STORE);
+
+/**
+ * Replays all the queued requests found in IndexedDB, by calling fetch()
+ * with an additional parameter indicating the offset from the original time.
+ *
+ * Returns a promise that resolves when the replaying is complete.
+ *
+ * @private
+ * @returns {Promise.<T>}
+ */
+module.exports = () => {
+  return idbHelper.getAllKeys().then(urls => {
+    return Promise.all(urls.map(url => {
+      return idbHelper.get(url).then(queuedTime => {
+        return fetch(`${url}&qt=${queuedTime}`).catch(error => {
+          // If this was queued recently, then rethrow the error, to prevent
+          // the entry from being deleted. It will be retried again later.
+          if ((Date.now() - queuedTime) < constants.STOP_RETRYING_AFTER) {
+            throw error;
+          }
+        });
+      }).then(() => idbHelper.delete(url));
+    }));
+  });
+};

--- a/projects/sw-offline-google-analytics/src/lib/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/src/lib/replay-queued-requests.js
@@ -15,6 +15,7 @@
 
 const IDBHelper = require('../../../../lib/idb-helper.js');
 const constants = require('./constants.js');
+const log = require('../../../../lib/log.js');
 
 const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
   constants.IDB.STORE);
@@ -26,14 +27,38 @@ const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
  * Returns a promise that resolves when the replaying is complete.
  *
  * @private
+ * @param {Object=} additionalParameters URL parameters, expressed as key/value
+ *                 pairs, to be added to replayed Google Analytics requests.
+ *                 This can be used to, e.g., set a custom dimension indicating
+ *                 that the request was replayed from the service worker.
  * @returns {Promise.<T>}
  */
-module.exports = () => {
+module.exports = additionalParameters => {
+  additionalParameters = additionalParameters || {};
+
   return idbHelper.getAllKeys().then(urls => {
     return Promise.all(urls.map(url => {
       return idbHelper.get(url).then(queuedTime => {
         const newUrl = new URL(url);
-        newUrl.search += (newUrl.search ? '&' : '') + 'qt=' + queuedTime;
+
+        // URLSearchParams was added in Chrome 49.
+        // On the off chance we're on a browser that lacks support, we won't
+        // set additionParameters, but at least we'll set qt=.
+        if ('searchParams' in newUrl) {
+          additionalParameters.qt = queuedTime;
+          // Call sort() on the keys so that there's a reliable order of calls
+          // to searchParams.set(). This isn't important in terms of
+          // functionality, but it will make testing easier, since the
+          // URL serialization depends on the order in which .set() is called.
+          Object.keys(additionalParameters).sort().forEach(parameter => {
+            newUrl.searchParams.set(parameter, additionalParameters[parameter]);
+          });
+        } else {
+          log('The browser does not support URLSearchParams, ' +
+            'so not setting additional parameters.');
+          newUrl.search += (newUrl.search ? '&' : '') + 'qt=' + queuedTime;
+        }
+
         return fetch(newUrl.toString()).catch(error => {
           // If this was queued recently, then rethrow the error, to prevent
           // the entry from being deleted. It will be retried again later.

--- a/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js
+++ b/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js
@@ -13,218 +13,75 @@
 
 /* eslint-env worker, serviceworker */
 
-(function(global) {
-  global.goog = global.goog || {};
+const constants = require('./lib/constants.js');
+const enqueueRequest = require('./lib/enqueue-request.js');
+const log = require('../../../lib/log.js');
+const replayQueuedRequests = require('./lib/replay-queued-requests.js');
+const scope = require('../../../lib/scope.js');
 
-  var log = global.goog.DEBUG ? console.debug.bind(console) : function() {};
+/**
+ * In order to use the library, call`goog.useOfflineGoogleAnalytics()`.
+ * It will take care of setting up service worker `fetch` handlers to ensure
+ * that the Google Analytics JavaScript is available offline, and that any
+ * Google Analytics requests made while offline are saved (using `IndexedDB`)
+ * and retried the next time the service worker starts up.
+ *
+ * @example
+ * // This code should live inside your service worker JavaScript, ideally
+ * // before any other 'fetch' event handlers are defined:
+ *
+ * // First, import the library into the service worker global scope:
+ * importScripts('path/to/offline-google-analytics-import.js');
+ *
+ * // Then, call goog.useOfflineGoogleAnalytics() to activate the library.:
+ * goog.useOfflineGoogleAnalytics();
+ *
+ * // At this point, implement any other service worker caching strategies
+ * // appropriate for your web app.
+ *
+ * @alias goog.useOfflineGoogleAnalytics
+ * @returns {undefined}
+ */
+const useOfflineGoogleAnalytics = () => {
+  self.addEventListener('fetch', event => {
+    const url = new URL(event.request.url);
+    const request = event.request;
 
-  var idbDatabase;
-  var IDB_VERSION = 1;
-  var STOP_RETRYING_AFTER = 86400000; // One day, in milliseconds.
-  var STORE_NAME = 'urls';
-  var CACHE_NAME = 'offline-google-analytics';
+    if (url.hostname === constants.URL.HOST) {
+      if (url.pathname === constants.URL.COLLECT_PATH) {
+        // If this is a /collect request, then use a network-first strategy,
+        // falling back to queueing the request in IndexedDB.
 
-  /**
-   * This is basic boilerplate for interacting with IndexedDB. Adapted from
-   * https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
-   *
-   * This is a private method that is exposed on the `goog` object to
-   * facilitate testing.
-   *
-   * @private
-   * @returns {undefined}
-   */
-  global.goog.openDatabaseAndReplayRequests = function() {
-    var indexedDBOpenRequest = indexedDB.open('offline-analytics', IDB_VERSION);
+        // Make a clone of the request before we use it, in case we need
+        // to read the request body later on.
+        const clonedRequest = request.clone();
 
-    // This top-level error handler will be invoked any time there's an
-    // IndexedDB-related error.
-    indexedDBOpenRequest.onerror = function(error) {
-      log('IndexedDB error:', error);
-    };
-
-    // This should only execute if there's a need to create a new database for
-    // the given IDB_VERSION.
-    indexedDBOpenRequest.onupgradeneeded = function() {
-      this.result.createObjectStore(STORE_NAME, {keyPath: 'url'});
-    };
-
-    // This will execute each time the database is opened.
-    indexedDBOpenRequest.onsuccess = function() {
-      idbDatabase = this.result;
-      replayAnalyticsRequests();
-    };
-  };
-
-  /**
-   * Helper method to get the object store that we care about.
-   *
-   * @private
-   * @param {String} storeName
-   * @param {String} mode
-   * @returns {IDBObjectStore}
-   */
-  function getObjectStore(storeName, mode) {
-    return idbDatabase.transaction(storeName, mode).objectStore(storeName);
-  }
-
-  /**
-   * Replays all the queued requests found in IndexedDB, by calling fetch()
-   * with an additional qt= parameter.
-   *
-   * @private
-   * @returns {undefined}
-   */
-  function replayAnalyticsRequests() {
-    var savedRequests = [];
-
-    getObjectStore(STORE_NAME).openCursor().onsuccess = function(event) {
-      // See https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#Using_a_cursor
-      var cursor = event.target.result;
-
-      if (cursor) {
-        // Keep moving the cursor forward and collecting saved requests.
-        savedRequests.push(cursor.value);
-        cursor.continue();
-      } else {
-        // At this point, we have all the saved requests.
-        savedRequests.forEach(function(savedRequest) {
-          var queueTime = Date.now() - savedRequest.timestamp;
-          if (queueTime > STOP_RETRYING_AFTER) {
-            getObjectStore(STORE_NAME, 'readwrite').delete(savedRequest.url);
-            log(' Request has been queued for %d milliseconds. ' +
-              'No longer attempting to replay.', queueTime);
-          } else {
-            // The qt= URL parameter specifies the time delta in between right
-            // now, and when the /collect request was initially attempted. See
-            // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
-            var requestUrl = savedRequest.url + '&qt=' + queueTime;
-
-            fetch(requestUrl).then(function(response) {
-              if (response.status < 400) {
-                // If sending the /collect request was successful, then remove
-                // it from the IndexedDB.
-                getObjectStore(STORE_NAME, 'readwrite').delete(
-                  savedRequest.url);
-              } else {
-                // This will be triggered if, e.g., Google Analytics returns a
-                // HTTP 50x response. The request will be replayed the next time
-                // the service worker starts up.
-                log(' Replaying failed:', response);
-              }
-            }).catch(function(error) {
-              // This will be triggered if the network is still down.
-              // The request will be replayed again the next time the service
-              // worker starts up.
-              log(' Replaying failed:', error);
+        event.respondWith(
+          fetch(request).catch(error => {
+            log('Enqueuing failed request...');
+            return enqueueRequest(clonedRequest).then(() => error);
+          })
+        );
+      } else if (url.pathname === constants.URL.ANALYTICS_JS_PATH) {
+        // If this is a request for the Google Analytics JavaScript library,
+        // use the network first, falling back to the previously cached copy.
+        event.respondWith(
+          caches.open(constants.CACHE_NAME).then(cache => {
+            return fetch(request).then(response => {
+              return cache.put(request, response.clone()).then(() => response);
+            }).catch(error => {
+              log(error);
+              return cache.match(request);
             });
-          }
-        });
+          })
+        );
       }
-    };
-  }
+    }
+  });
 
-  /**
-   * Adds a URL to IndexedDB, along with the current timestamp.
-   *
-   * This is a private method that is exposed on the `goog` object to
-   * facilitate testing.
-   *
-   * @private
-   * @param {Request} request
-   * @returns {undefined}
-   */
-  global.goog.enqueueRequest = function(request) {
-    var url = new URL(request.url);
-    // TODO: This is done asynchronously without coordinating its completion
-    // with the fetch handler that triggers it. It should ideally return
-    // a promise that reflects the status of the IndexedDB transaction, and
-    // the fetch handler should call event.waitUntil() on that promise.
-    // In the current implementation, there's a very small chance the service
-    // worker will be killed before the IndexedDB transaction completes.
-    request.text().then(function(body) {
-      // If there's a request body, then use it as the URL's search value.
-      // This is most likely because the original request was an HTTP POST
-      // that uses the beacon transport.
-      if (body) {
-        url.search = body;
-      }
+  replayQueuedRequests();
+};
 
-      getObjectStore(STORE_NAME, 'readwrite').add({
-        url: url.toString(),
-        timestamp: Date.now()
-      });
-    });
-  };
-
-  /**
-   * `goog.useOfflineGoogleAnalytics` is the main entry point to the library
-   * from within service worker code.
-   *
-   * ```js
-   * // Inside your service worker JavaScript, ideally before any other
-   * // 'fetch' event handlers are defined:
-   *
-   * // 1) Import the library into the service worker global scope, using
-   * // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
-   * importScripts('path/to/offline-google-analytics-import.js');
-   *
-   * // 2) Call goog.useOfflineGoogleAnalytics() to activate the library.
-   * goog.useOfflineGoogleAnalytics();
-   *
-   * // At this point, implement any other service worker caching strategies
-   * // appropriate for your web app.
-   * ```
-   *
-   * @alias goog.useOfflineGoogleAnalytics
-   * @returns {undefined}
-   */
-  global.goog.useOfflineGoogleAnalytics = function() {
-    // Open the IndexedDB and check for requests to replay each time the service
-    // worker starts up.
-    // Since the service worker is terminated fairly frequently, it should start
-    // up again for most page navigations. It also might start up if it's used
-    // in a background sync or a push notification context.
-    global.goog.openDatabaseAndReplayRequests();
-
-    global.addEventListener('fetch', function(event) {
-      var url = new URL(event.request.url);
-      var request = event.request;
-
-      if ((url.hostname === 'www.google-analytics.com' ||
-           url.hostname === 'ssl.google-analytics.com')) {
-        if (url.pathname === '/collect') {
-          // If this is a /collect request, then use a network-first strategy,
-          // falling back to queueing the request in IndexedDB.
-
-          // Make a clone of the request before we use it, in case we need
-          // to read the request body later on.
-          var clonedRequest = request.clone();
-
-          event.respondWith(
-            fetch(request).catch(function(error) {
-              global.goog.enqueueRequest(clonedRequest);
-
-              return error;
-            })
-          );
-        } else if (url.pathname === '/analytics.js') {
-          // If this is a request for the Google Analytics JavaScript library,
-          // use the network first, falling back to the previously cached copy.
-          event.respondWith(
-            caches.open(CACHE_NAME).then(function(cache) {
-              return fetch(request).then(function(response) {
-                return cache.put(request, response.clone()).then(function() {
-                  return response;
-                });
-              }).catch(function(error) {
-                log(error);
-                return cache.match(request);
-              });
-            })
-          );
-        }
-      }
-    });
-  };
-})(self);
+// Add the function to the global service worker scope,
+// as goog.useOfflineGoogleAnalytics.
+scope('useOfflineGoogleAnalytics', useOfflineGoogleAnalytics);

--- a/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js
+++ b/projects/sw-offline-google-analytics/src/offline-google-analytics-import.js
@@ -38,8 +38,9 @@ const scope = require('../../../lib/scope.js');
  *   parameterOverrides: {
  *     // Optionally, pass in an Object with additional parameters that will be
  *     // included in each replayed request.
- *     dimension1: 'Some Value',
- *     dimension2: 'Some Other Value'
+ *     // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+ *     cd1: 'Some Value',
+ *     cd2: 'Some Other Value'
  *   }
  * });
  *
@@ -48,10 +49,11 @@ const scope = require('../../../lib/scope.js');
  *
  * @alias goog.offlineGoogleAnalytics.initialize
  * @param {Object=} config Optional configuration arguments.
- * @param {Object=} config.parameterOverrides Optional URL parameters, expressed
- *                  as key/value pairs, to be added to replayed Google Analytics
- *                  requests. This can be used to, e.g., set a custom dimension
- *                  indicating that the request was replayed.
+ * @param {Object=} config.parameterOverrides Optional
+ *                  [Measurement Protocol parameters](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters),
+ *                  expressed as key/value pairs, to be added to replayed Google
+ *                  Analytics requests. This can be used to, e.g., set a custom
+ *                  dimension indicating that the request was replayed.
  * @returns {undefined}
  */
 const initialize = config => {

--- a/projects/sw-offline-google-analytics/test/automated-suite.js
+++ b/projects/sw-offline-google-analytics/test/automated-suite.js
@@ -23,10 +23,7 @@
 // documentation here: http://selenium.googlecode.com/git/docs/api/javascript/index.html
 
 const browserifyTests = require('../../../lib/browserify-tests.js');
-const chai = require('chai');
-const del = require('del');
 const path = require('path');
-const promisify = require('promisify-node');
 const swTestingHelpers = require('sw-testing-helpers');
 
 const automatedBrowserTesting = swTestingHelpers.automatedBrowserTesting;

--- a/projects/sw-offline-google-analytics/test/automated-suite.js
+++ b/projects/sw-offline-google-analytics/test/automated-suite.js
@@ -1,0 +1,89 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+'use strict';
+
+/* eslint-env node, mocha, browser, serviceworker */
+/* eslint-disable max-len, no-unused-expressions */
+
+// These tests make use of selenium-webdriver. You can find the relevant
+// documentation here: http://selenium.googlecode.com/git/docs/api/javascript/index.html
+
+const browserifyTests = require('../../../lib/browserify-tests.js');
+const chai = require('chai');
+const del = require('del');
+const path = require('path');
+const promisify = require('promisify-node');
+const swTestingHelpers = require('sw-testing-helpers');
+
+const automatedBrowserTesting = swTestingHelpers.automatedBrowserTesting;
+const testServer = new swTestingHelpers.TestServer();
+const TIMEOUT = 10 * 1000;
+
+describe('sw-offline-google-analytics Test Suite', function() {
+  this.timeout(TIMEOUT);
+  let baseTestUrl;
+
+  // Set up the web server before running any tests in this suite.
+  before(function() {
+    const baseDirectory = __dirname.replace(path.sep, '/');
+    return browserifyTests(`${baseDirectory}/unit/`).then(() => {
+      return testServer.startServer('.').then(portNumber => {
+        baseTestUrl = `http://localhost:${portNumber}/projects/sw-offline-google-analytics/test/`;
+      });
+    });
+  });
+
+  // Kill the web server once all tests are complete.
+  after(function() {
+    return testServer.killServer();
+  });
+
+  automatedBrowserTesting.getDiscoverableBrowsers().forEach(function(browser) {
+    let driver = null;
+
+    // Before each sub-suite, initialize a new driver so that we can start with
+    // a fresh environment.
+    before(function() {
+      driver = browser.getSeleniumDriver();
+      driver.manage().timeouts().setScriptTimeout(TIMEOUT);
+    });
+
+    // Tear down the driver at the end of each sub-suite.
+    after(function() {
+      return automatedBrowserTesting.killWebDriver(driver);
+    });
+
+    describe(`Unit Tests (${browser.getPrettyName()})`, function() {
+      it('should pass all tests', function() {
+        return swTestingHelpers.mochaUtils.startWebDriverMochaTests(
+          browser.getPrettyName(),
+          driver,
+          `${baseTestUrl}unit/`
+        ).then(function(testResults) {
+          if (testResults.failed.length > 0) {
+            const errorMessage = swTestingHelpers.mochaUtils.prettyPrintErrors(
+              browser.prettyName,
+              testResults
+            );
+
+            throw new Error(errorMessage);
+          }
+        });
+      });
+    });
+  });
+});

--- a/projects/sw-offline-google-analytics/test/unit/enqueue-request.js
+++ b/projects/sw-offline-google-analytics/test/unit/enqueue-request.js
@@ -1,0 +1,44 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env mocha, browser */
+
+'use strict';
+
+const IDBHelper = require('../../../../lib/idb-helper.js');
+const constants = require('../../src/lib/constants.js');
+const enqueueRequest = require('../../src/lib/enqueue-request.js');
+
+const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+  constants.IDB.STORE);
+
+describe('enqueue-request', () => {
+  it('should write to IndexedDB', () => {
+    const url = 'https://enqueue-request.com/?random=' + Math.random();
+    const request = new Request(url);
+    return enqueueRequest(request)
+      .then(() => idbHelper.getAllKeys())
+      .then(keys => chai.expect(keys).to.include(url));
+  });
+
+  it('should use the request body, when present, in the IndexedDB key', () => {
+    const baseUrl = 'https://enqueue-request.com/';
+    const body = 'random=' + Math.random();
+    const url = `${baseUrl}?${body}`;
+
+    const request = new Request(url, {method: 'POST', body});
+    return enqueueRequest(request, time)
+      .then(() => idbHelper.getAllKeys())
+      .then(keys => chai.expect(keys).to.include(url));
+  });
+});

--- a/projects/sw-offline-google-analytics/test/unit/enqueue-request.js
+++ b/projects/sw-offline-google-analytics/test/unit/enqueue-request.js
@@ -12,6 +12,7 @@
  */
 
 /* eslint-env mocha, browser */
+/* global chai */
 
 'use strict';
 
@@ -37,7 +38,7 @@ describe('enqueue-request', () => {
     const url = `${baseUrl}?${body}`;
 
     const request = new Request(url, {method: 'POST', body});
-    return enqueueRequest(request, time)
+    return enqueueRequest(request)
       .then(() => idbHelper.getAllKeys())
       .then(keys => chai.expect(keys).to.include(url));
   });

--- a/projects/sw-offline-google-analytics/test/unit/index.html
+++ b/projects/sw-offline-google-analytics/test/unit/index.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright 2016 Google Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>SW Toolbox Tests</title>
+    <link href="/node_modules/mocha/mocha.css" rel="stylesheet" />
+
+    <!--
+      iframes are used to manage service worker scoping.
+      This will hide them and stop the page from jumping around
+    -->
+    <style>
+      iframe {
+        width: 0;
+        height: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/mocha/mocha.js"></script>
+
+    <!-- sw-testing-helpers -->
+    <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
+
+    <!--
+      Timeout is extended to ensure tests for max-cache-age
+      have enough time to complete
+    -->
+    <script>mocha.setup({
+      ui: 'bdd',
+      timeout: 10000
+    })</script>
+
+    <!-- In browser test scripts should be added to the page here-->
+    <script src="build/replay-queued-requests.js"></script>
+    <script src="build/enqueue-request.js"></script>
+
+    <script>
+      (function() {
+        // This make browsers without a service worker pass tests by
+        // bypassing the tests altogether.
+        // This is desirable to allow travis to run tests in all browsers
+        // regardless of support or not and perform tests when the browser
+        // starts to support service workers.
+        if (!('serviceWorker' in navigator)) {
+          publishTestResults();
+          return;
+        }
+
+        window.goog.mochaUtils.startInBrowserMochaTests().then(results => {
+          window.testsuite = results;
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
@@ -12,6 +12,7 @@
  */
 
 /* eslint-env mocha, browser */
+/* global chai */
 
 'use strict';
 
@@ -43,7 +44,8 @@ describe('replay-queued-requests', () => {
     return Promise.all(urls.map(url => enqueueRequest(new Request(url), time)))
       .then(() => replayRequests())
       .then(() => fetchMock.calls().matched.map(match => match[0]))
-      .then(matchedUrls => chai.expect(matchedUrls).to.include.members(urlsWithQt))
+      .then(matchedUrls =>
+        chai.expect(matchedUrls).to.include.members(urlsWithQt))
       .then(() => idbHelper.getAllKeys())
       .then(keys => chai.expect(keys).to.not.include.members(urlsWithQt));
   });

--- a/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
@@ -1,0 +1,54 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env mocha, browser */
+
+'use strict';
+
+const IDBHelper = require('../../../../lib/idb-helper.js');
+const constants = require('../../src/lib/constants.js');
+const enqueueRequest = require('../../src/lib/enqueue-request');
+const fetchMock = require('fetch-mock');
+const replayRequests = require('../../src/lib/replay-queued-requests.js');
+
+const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+  constants.IDB.STORE);
+
+describe('replay-queued-requests', () => {
+  const urlPrefix = 'https://replay-queued-requests.com/';
+
+  before(() => {
+    fetchMock.mock(`^${urlPrefix}`, new Response());
+  });
+
+  it('should replay requests saved in IndexedDB', () => {
+    const urls = ['one', 'two?three=4'].map(suffix => urlPrefix + suffix);
+    const time = Date.now();
+    const urlsWithQt = urls.map(url => {
+      const newUrl = new URL(url);
+      newUrl.search += (newUrl.search ? '&' : '') + 'qt=' + time;
+      return newUrl.toString();
+    });
+
+    return Promise.all(urls.map(url => enqueueRequest(new Request(url), time)))
+      .then(() => replayRequests())
+      .then(() => fetchMock.calls().matched.map(match => match[0]))
+      .then(matchedUrls => chai.expect(matchedUrls).to.include.members(urlsWithQt))
+      .then(() => idbHelper.getAllKeys())
+      .then(keys => chai.expect(keys).to.not.include.members(urlsWithQt));
+  });
+
+  after(() => {
+    fetchMock.restore();
+  });
+});

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -1,7 +1,5 @@
 <!-- To make changes, edit templates/README.hbs, not README.md! -->
-[![NPM version][npm-image]][npm-url]
 [![Build Status][travis-image]][travis-url]
-[![devDependency Status](https://david-dm.org/googlechrome/sw-helpers/dev-status.svg)](https://david-dm.org/googlechrome/sw-helpers#info=devDependencies)
 
 # Service Worker Helpers
 


### PR DESCRIPTION
R: @addyosmani @wibblymat @gauntface
CC: @philipwalton @igrigorik 

Fixes #8 #19 

This adds the code for a new `sw-offline-google-analytics` project, along with a quick demo and tests. The underlying code is conceptually similar to what's been deployed elsewhere as part of larger projects (like IOWA), and I've gotten some feedback on it from @igrigorik and @philipwalton in the past.

One of the larger changes to that existing codebase was to refactor the imported code into a couple of different modules that handle IndexedDB interactions. I then wrote some tests against those modules. Hopefully this makes up to some extent for not being able to put together a meaningful end-to-end automated test that simulates a lack of network connectivity.