### PR TITLE
Fixes the test of the qt= parameter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-rename": "^1.2.2",
     "idb": "^1.1.0",
     "minimist": "^1.2.0",
+    "mockdate": "^1.0.4",
     "npm-path": "^1.1.0",
     "parse-appcache-manifest": "^0.2.0",
     "promisify-node": "^0.4.0",

--- a/projects/sw-offline-google-analytics/package.json
+++ b/projects/sw-offline-google-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sw-offline-google-analytics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A service worker helper library to retry offline Google Analytics requests when a connection is available.",
   "keywords": [
     "service worker",

--- a/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const IDBHelper = require('../../../../lib/idb-helper.js');
+const MockDate = require('mockdate');
 const constants = require('../../src/lib/constants.js');
 const enqueueRequest = require('../../src/lib/enqueue-request');
 const fetchMock = require('fetch-mock');
@@ -38,17 +39,24 @@ const testLogic = (initialUrls, expectedUrls, time, additionalParameters) => {
 
 describe('replay-queued-requests', () => {
   const urlPrefix = 'https://replay-queued-requests.com/';
+  const initialTimestamp = 1470405670000;
+  const timestampOffset = 1000;
 
   before(() => {
     fetchMock.mock(`^${urlPrefix}`, new Response());
+    MockDate.set(initialTimestamp + timestampOffset);
+  });
+
+  after(() => {
+    MockDate.reset();
   });
 
   it('should replay queued requests', () => {
     const urls = ['one', 'two?three=4'].map(suffix => urlPrefix + suffix);
-    const time = Date.now();
+    const time = initialTimestamp;
     const urlsWithQt = urls.map(url => {
       const newUrl = new URL(url);
-      newUrl.searchParams.set('qt', time);
+      newUrl.searchParams.set('qt', timestampOffset);
       return newUrl.toString();
     });
 
@@ -57,11 +65,11 @@ describe('replay-queued-requests', () => {
 
   it('should replay queued requests with additional parameters', () => {
     const urls = ['one', 'two?three=4'].map(suffix => urlPrefix + suffix);
-    const time = Date.now();
+    const time = initialTimestamp;
     const additionalParameters = {
       three: 5,
       four: 'six',
-      qt: time
+      qt: timestampOffset
     };
     const urlsWithAdditionalParameters = urls.map(url => {
       const newUrl = new URL(url);

--- a/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
+++ b/projects/sw-offline-google-analytics/test/unit/replay-queued-requests.js
@@ -39,8 +39,8 @@ const testLogic = (initialUrls, expectedUrls, time, additionalParameters) => {
 
 describe('replay-queued-requests', () => {
   const urlPrefix = 'https://replay-queued-requests.com/';
-  const initialTimestamp = 1470405670000;
-  const timestampOffset = 1000;
+  const initialTimestamp = 1470405670000; // An arbitrary, but valid, timestamp in milliseconds.
+  const timestampOffset = 1000; // A 1000 millisecond offset.
 
   before(() => {
     fetchMock.mock(`^${urlPrefix}`, new Response());


### PR DESCRIPTION
R: @philipwalton 
CC: @addyosmani @wibblymat @gauntface

Fixes #35 

Mocks Date.now() so that we can reliably test the `qt=` offset.

It also bumps the version in `package.json` to 1.0.1, to get it ready to be deployed.

Tests are still broken in Firefox; that's being tracked in #22 