### PR TITLE
Moves to sw-testing-helpers 0.1.1

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -124,7 +124,8 @@ gulp.task('lint', () => {
 gulp.task('test', () => {
   return gulp.src(`projects/${projectOrStar}/test/*.js`, {read: false})
     .pipe(mocha())
-    .once('error', () => {
+    .once('error', error => {
+      console.error(error);
       process.exit(1);
     });
 });

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "parse-appcache-manifest": "^0.2.0",
     "promisify-node": "^0.4.0",
     "run-sequence": "^1.1.5",
+    "selenium-assistant": "^0.3.0",
     "serve-index": "^1.7.3",
     "serve-static": "^1.10.2",
-    "sw-testing-helpers": "0.0.14",
+    "sw-testing-helpers": "0.1.1",
     "tmp": "0.0.28"
   }
 }


### PR DESCRIPTION
R: @gauntface 
CC: @ebidel @addyosmani @wibblymat 

Fixes #22

This updates the project to use the 0.1.1 release of `sw-testing-helpers` along with the new `selenium-assistant` dependency.

_Unforunately_, this still leads to broken tests with Firefox. While we are now using the Marionette driver, which works with Firefox 48+, the combination of Marionette + `selenium-webdriver` 2.53 makes it impossible to set the async script timeout. So the Travis CI tests are still failing.

https://github.com/GoogleChrome/sw-testing-helpers/issues/48 tracks updating `sw-testing-helpers` to use `selenenium-webdriver` 3.0 betas, which fixes the issue with timeouts.