### PR TITLE
changing gulp serve directory

### DIFF
--- a/gulp-tasks/serve.js
+++ b/gulp-tasks/serve.js
@@ -24,8 +24,8 @@ const serveStatic = require('serve-static');
 gulp.task('serve', (unusedCallback) => {
   const app = express();
   const rootDirectory = global.projectOrStar === '*' ?
-    'projects' :
-    path.join('projects', global.projectOrStar);
+    'packages' :
+    path.join('packages', global.projectOrStar);
 
   app.use(serveStatic(rootDirectory));
   app.use(serveIndex(rootDirectory, {view: 'details'}));


### PR DESCRIPTION
R: @jeffposnick @addyosmani @wibblymat @gauntface @ebidel

Fixes #*issue number*

'gulp serve' currently serve out of projects folder where as I see all the code has moved to 'packages' folder

*Please ensure that `gulp lint test` passes locally prior to filing a PR!*

