### PR TITLE
Adding back in in the analytics suite

### DIFF
--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module",
+  }
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "selenium-assistant": "^3.0.0",
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
+    "sinon": "^1.17.6",
     "sw-testing-helpers": "0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,10 @@
     "blueimp-md5": "^2.3.1",
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
-    "chromedriver": "^2.24.1",
+    "chromedriver": "^2.25.1",
     "documentation": "^4.0.0-beta11",
     "eslint-config-google": "^0.7.0",
     "express": "^4.14.0",
-    "fetch-mock": "^5.1.5",
     "fs-extra": "^0.30.0",
     "geckodriver": "^1.1.3",
     "gh-pages": "^0.11.0",
@@ -63,6 +62,7 @@
     "selenium-assistant": "^3.0.0",
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
+    "sinon": "^1.17.6",
     "sw-testing-helpers": "0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "selenium-assistant": "^3.0.0",
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
-    "sinon": "^1.17.6",
     "sw-testing-helpers": "0.1.4"
   }
 }

--- a/packages/sw-offline-google-analytics/.eslintrc
+++ b/packages/sw-offline-google-analytics/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module",
+  }
+}

--- a/packages/sw-offline-google-analytics/.npmignore
+++ b/packages/sw-offline-google-analytics/.npmignore
@@ -1,0 +1,1 @@
+build/test/

--- a/packages/sw-offline-google-analytics/README.md
+++ b/packages/sw-offline-google-analytics/README.md
@@ -8,14 +8,14 @@ A service worker helper library to retry offline Google Analytics requests when 
 
 ## Demo
 
-Browse sample source code in the [demo directory](https://github.com/GoogleChrome/sw-helpers/tree/master/projects/sw-offline-google-analytics/demo), or
+Browse sample source code in the [demo directory](https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics/demo), or
 [try it out](https://googlechrome.github.io/sw-helpers/sw-offline-google-analytics/demo/) directly.
 
 ## API
 
 ### goog.offlineGoogleAnalytics.initialize
 
-[projects/sw-offline-google-analytics/src/index.js:82-132](https://github.com/GoogleChrome/sw-helpers/blob/6618776516d4738d9626f115ff44d643ede71903/projects/sw-offline-google-analytics/src/index.js#L82-L132 "Source code on GitHub")
+[packages/sw-offline-google-analytics/src/index.js:82-132](https://github.com/GoogleChrome/sw-helpers/blob/6618776516d4738d9626f115ff44d643ede71903/packages/sw-offline-google-analytics/src/index.js#L82-L132 "Source code on GitHub")
 
 In order to use the library, call`goog.offlineGoogleAnalytics.initialize()`.
 It will take care of setting up service worker `fetch` handlers to ensure
@@ -81,4 +81,4 @@ goog.offlineGoogleAnalytics.initialize({
 });
 ```
 
-Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)** 
+Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)**

--- a/packages/sw-offline-google-analytics/README.md
+++ b/packages/sw-offline-google-analytics/README.md
@@ -1,0 +1,84 @@
+# sw-offline-google-analytics
+
+A service worker helper library to retry offline Google Analytics requests when a connection is available.
+
+## Installation
+
+`npm install --save-dev sw-offline-google-analytics`
+
+## Demo
+
+Browse sample source code in the [demo directory](https://github.com/GoogleChrome/sw-helpers/tree/master/projects/sw-offline-google-analytics/demo), or
+[try it out](https://googlechrome.github.io/sw-helpers/sw-offline-google-analytics/demo/) directly.
+
+## API
+
+### goog.offlineGoogleAnalytics.initialize
+
+[projects/sw-offline-google-analytics/src/index.js:82-132](https://github.com/GoogleChrome/sw-helpers/blob/6618776516d4738d9626f115ff44d643ede71903/projects/sw-offline-google-analytics/src/index.js#L82-L132 "Source code on GitHub")
+
+In order to use the library, call`goog.offlineGoogleAnalytics.initialize()`.
+It will take care of setting up service worker `fetch` handlers to ensure
+that the Google Analytics JavaScript is available offline, and that any
+Google Analytics requests made while offline are saved (using `IndexedDB`)
+and retried the next time the service worker starts up.
+
+**Parameters**
+
+-   `config` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional configuration arguments.
+    -   `config.parameterOverrides` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Optional
+                           [Measurement Protocol parameters](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters),
+                           expressed as key/value pairs, to be added to replayed
+                           Google Analytics requests. This can be used to, e.g., set
+                           a custom dimension indicating that the request was
+                           replayed.
+    -   `config.hitFilter` **\[[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)]** Optional
+                           A function that allows you to modify the hit parameters
+                           prior to replaying the hit. The function is invoked with
+                           the original hit's URLSearchParams object as its only
+                           argument. To abort the hit and prevent it from being
+                           replayed, throw an error.
+
+**Examples**
+
+```javascript
+// This code should live inside your service worker JavaScript, ideally
+// before any other 'fetch' event handlers are defined:
+
+// First, import the library into the service worker global scope:
+importScripts('path/to/offline-google-analytics-import.js');
+
+// Then, call goog.offlineGoogleAnalytics.initialize():
+goog.offlineGoogleAnalytics.initialize();
+
+// At this point, implement any other service worker caching strategies
+// appropriate for your web app.
+```
+
+```javascript
+// If you need to specify parameters to be sent with each hit, you can use
+// the `parameterOverrides` configuration option. This is useful in cases
+// where you want to set a custom dimension on all hits sent by the service
+// worker to differentiate them in your reports later.
+goog.offlineGoogleAnalytics.initialize({
+  parameterOverrides: {
+    cd1: 'replay'
+  }
+});
+```
+
+```javascript
+// In situations where you need to programmatically modify a hit's
+// parameters you can use the `hitFilter` option. One example of when this
+// might be useful is if you wanted to track the amount of time that elapsed
+// between when the hit was attempted and when it was successfully replayed.
+goog.offlineGoogleAnalytics.initialize({
+  hitFilter: searchParams =>
+    // Sets the `qt` param as a custom metric.
+    const qt = searchParams.get('qt');
+    searchParams.set('cm1', qt);
+  }
+});
+```
+
+Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)** 

--- a/packages/sw-offline-google-analytics/build.js
+++ b/packages/sw-offline-google-analytics/build.js
@@ -1,0 +1,108 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+const resolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+const path = require('path');
+const {buildJSBundle} = require('../../build-utils');
+
+module.exports = () => {
+  return Promise.all([
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, 'src', 'index.js'),
+        format: 'umd',
+        moduleName: 'goog.offlineGoogleAnalytics',
+        plugins: [
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: 'build/offline-google-analytics-import.js',
+      projectDir: __dirname,
+    }),
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, 'src', 'lib', 'enqueue-request.js'),
+        format: 'umd',
+        moduleName: 'goog.offlineGoogleAnalytics.test.enqueueRequest',
+        plugins: [
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: 'build/test/enqueue-request.js',
+      projectDir: __dirname,
+    }),
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, 'src', 'lib', 'replay-queued-requests.js'),
+        format: 'umd',
+        moduleName: 'goog.offlineGoogleAnalytics.test.replayRequests',
+        plugins: [
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: 'build/test/replay-queued-requests.js',
+      projectDir: __dirname,
+    }),
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
+        format: 'umd',
+        moduleName: 'goog.offlineGoogleAnalytics.test.constants',
+        plugins: [
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: 'build/test/constants.js',
+      projectDir: __dirname,
+    }),
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, '..', '..', 'lib', 'idb-helper.js'),
+        format: 'umd',
+        moduleName: 'goog.offlineGoogleAnalytics.test.IDBHelper',
+        plugins: [
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: 'build/test/idb-helper.js',
+      projectDir: __dirname,
+    }),
+  ]);
+};

--- a/packages/sw-offline-google-analytics/demo/index.html
+++ b/packages/sw-offline-google-analytics/demo/index.html
@@ -1,0 +1,51 @@
+<html>
+  <head>
+    <title>Offline Google Analytics Demo</title>
+  </head>
+  <body>
+    <p>
+      This is a simple demo showing how you can use
+      <code>sw-offline-google-analytics</code> to queue up and resend Google
+      Analytics requests when your web app is accessed while a user is offline.
+    </p>
+    <p>
+      Try revisiting this page while offline (either by disconnecting from your
+      network, or via Chrome DevTool's offline emulation) and then clicking
+      on the button below to trigger new Google Analytics requests. The requests
+      will be queued up in IndexedDB, and then retried the next time this
+      page's service worker starts up.
+    </p>
+    <button id="send">Send GA Event</button>
+
+    <script>
+      // Set up Google Analytics.
+      (function(i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        i[r] = i[r] || function() {
+          (i[r].q = i[r].q || []).push(arguments);
+        };
+        i[r].l = 1 * new Date();
+        a = s.createElement(o);
+        m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+      })(window, document, 'script',
+        'https://www.google-analytics.com/analytics.js', 'ga');
+      ga('create', 'UA-REPLACE_ME-1', 'auto');
+      // The library works the same way when using the sendBeacon transport.
+      // ga('set', 'transport', 'beacon');
+      ga('send', 'pageview');
+
+      // Register our service worker.
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('service-worker.js');
+      }
+
+      // Handle button clicks by triggering Google Analytics events.
+      document.querySelector('#send').addEventListener('click', function() {
+        ga('send', 'event', 'test', 'click');
+      });
+    </script>
+  </body>
+</html>

--- a/packages/sw-offline-google-analytics/demo/service-worker.js
+++ b/packages/sw-offline-google-analytics/demo/service-worker.js
@@ -1,0 +1,35 @@
+/* eslint-env worker, serviceworker */
+/* global goog */
+
+const CACHE_NAME = 'runtime-caching';
+self.goog = {DEBUG: true};
+importScripts('../build/offline-google-analytics-import.js');
+
+// First, enable the offline Google Analytics behavior.
+// This will get "first shot" at responding to Google Analytics requests, before
+// our catch-all fetch event listener can handle it.
+goog.offlineGoogleAnalytics.initialize({
+  parameterOverrides: {
+    // Add in any additional parameters here, or omit this section to
+    // replay the Google Analytics request without additional parameters.
+    // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+    cd1: 'My Custom Dimension Value',
+  },
+});
+
+// Use a basic network-first caching strategy as a catch-all for everything
+// other than the Google Analytics requests.
+// (In a real app, you'd want to use a more sophisticated caching technique.)
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.open(CACHE_NAME).then((cache) => {
+      return fetch(event.request).then((response) => {
+        return cache.put(event.request, response.clone()).then(() => response);
+      }).catch(() => cache.match(event.request));
+    })
+  );
+});
+
+// Have the service worker take control as soon as possible.
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());

--- a/packages/sw-offline-google-analytics/package.json
+++ b/packages/sw-offline-google-analytics/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sw-offline-google-analytics",
+  "version": "1.1.1",
+  "description": "A service worker helper library to retry offline Google Analytics requests when a connection is available.",
+  "keywords": [
+    "service worker",
+    "sw",
+    "offline",
+    "analytics"
+  ],
+  "author": {
+    "name": "Jeff Posnick",
+    "email": "jeffy@google.com",
+    "url": "https://jeffy.info"
+  },
+  "license": "Apache-2.0",
+  "repository": "googlechrome/sw-helpers",
+  "bugs": "https://github.com/googlechrome/sw-helpers/issues",
+  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/projects/sw-offline-google-analytics"
+}

--- a/packages/sw-offline-google-analytics/package.json
+++ b/packages/sw-offline-google-analytics/package.json
@@ -16,5 +16,5 @@
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",
-  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/projects/sw-offline-google-analytics"
+  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics"
 }

--- a/packages/sw-offline-google-analytics/src/index.js
+++ b/packages/sw-offline-google-analytics/src/index.js
@@ -1,0 +1,134 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env worker, serviceworker */
+
+import constants from './lib/constants.js';
+import enqueueRequest from './lib/enqueue-request.js';
+import log from '../../../lib/log.js';
+import replayQueuedRequests from './lib/replay-queued-requests.js';
+
+/**
+ * In order to use the library, call`goog.offlineGoogleAnalytics.initialize()`.
+ * It will take care of setting up service worker `fetch` handlers to ensure
+ * that the Google Analytics JavaScript is available offline, and that any
+ * Google Analytics requests made while offline are saved (using `IndexedDB`)
+ * and retried the next time the service worker starts up.
+ *
+ * @example
+ * // This code should live inside your service worker JavaScript, ideally
+ * // before any other 'fetch' event handlers are defined:
+ *
+ * // First, import the library into the service worker global scope:
+ * importScripts('path/to/offline-google-analytics-import.js');
+ *
+ * // Then, call goog.offlineGoogleAnalytics.initialize():
+ * goog.offlineGoogleAnalytics.initialize();
+ *
+ * // At this point, implement any other service worker caching strategies
+ * // appropriate for your web app.
+ *
+ * @example
+ * // If you need to specify parameters to be sent with each hit, you can use
+ * // the `parameterOverrides` configuration option. This is useful in cases
+ * // where you want to set a custom dimension on all hits sent by the service
+ * // worker to differentiate them in your reports later.
+ * goog.offlineGoogleAnalytics.initialize({
+ *   parameterOverrides: {
+ *     cd1: 'replay'
+ *   }
+ * });
+ *
+ * @example
+ * // In situations where you need to programmatically modify a hit's
+ * // parameters you can use the `hitFilter` option. One example of when this
+ * // might be useful is if you wanted to track the amount of time that elapsed
+ * // between when the hit was attempted and when it was successfully replayed.
+ * goog.offlineGoogleAnalytics.initialize({
+ *   hitFilter: searchParams =>
+ *     // Sets the `qt` param as a custom metric.
+ *     const qt = searchParams.get('qt');
+ *     searchParams.set('cm1', qt);
+ *   }
+ * });
+ *
+ *
+ * @alias goog.offlineGoogleAnalytics.initialize
+ * @param {Object=}   config Optional configuration arguments.
+ * @param {Object=}   config.parameterOverrides Optional
+ *                    [Measurement Protocol parameters](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters),
+ *                    expressed as key/value pairs, to be added to replayed
+ *                    Google Analytics requests. This can be used to, e.g., set
+ *                    a custom dimension indicating that the request was
+ *                    replayed.
+ * @param {Function=} config.hitFilter Optional
+ *                    A function that allows you to modify the hit parameters
+ *                    prior to replaying the hit. The function is invoked with
+ *                    the original hit's URLSearchParams object as its only
+ *                    argument. To abort the hit and prevent it from being
+ *                    replayed, throw an error.
+ * @return {undefined}
+ */
+const initialize = (config) => {
+  config = config || {};
+
+  // Stores whether or not the previous /collect request failed.
+  let previousHitFailed = false;
+
+  self.addEventListener('fetch', (event) => {
+    const url = new URL(event.request.url);
+    const request = event.request;
+
+    if (url.hostname === constants.URL.HOST) {
+      if (url.pathname === constants.URL.COLLECT_PATH) {
+        // If this is a /collect request, then use a network-first strategy,
+        // falling back to queueing the request in IndexedDB.
+
+        // Make a clone of the request before we use it, in case we need
+        // to read the request body later on.
+        const clonedRequest = request.clone();
+
+        event.respondWith(
+          fetch(request).then((response) => {
+            if (previousHitFailed) {
+              replayQueuedRequests(config);
+            }
+            previousHitFailed = false;
+            return response;
+          }, (error) => {
+            log('Enqueuing failed request...');
+            previousHitFailed = true;
+            return enqueueRequest(clonedRequest).then(() => Response.error());
+          })
+        );
+      } else if (url.pathname === constants.URL.ANALYTICS_JS_PATH) {
+        // If this is a request for the Google Analytics JavaScript library,
+        // use the network first, falling back to the previously cached copy.
+        event.respondWith(
+          caches.open(constants.CACHE_NAME).then((cache) => {
+            return fetch(request).then((response) => {
+              return cache.put(request, response.clone()).then(() => response);
+            }).catch((error) => {
+              log(error);
+              return cache.match(request);
+            });
+          })
+        );
+      }
+    }
+  });
+
+  replayQueuedRequests(config);
+};
+
+export default {initialize};

--- a/packages/sw-offline-google-analytics/src/lib/constants.js
+++ b/packages/sw-offline-google-analytics/src/lib/constants.js
@@ -1,0 +1,30 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+export default {
+  CACHE_NAME: 'offline-google-analytics',
+  IDB: {
+    NAME: 'offline-google-analytics',
+    STORE: 'urls',
+    VERSION: 1,
+  },
+  MAX_ANALYTICS_BATCH_SIZE: 20,
+  STOP_RETRYING_AFTER: 1000 * 60 * 60 * 48, // Two days, in milliseconds.
+  URL: {
+    ANALYTICS_JS_PATH: '/analytics.js',
+    COLLECT_PATH: '/collect',
+    HOST: 'www.google-analytics.com',
+  },
+};

--- a/packages/sw-offline-google-analytics/src/lib/enqueue-request.js
+++ b/packages/sw-offline-google-analytics/src/lib/enqueue-request.js
@@ -1,0 +1,47 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env worker, serviceworker */
+
+import IDBHelper from '../../../../lib/idb-helper.js';
+import constants from './constants.js';
+
+const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+  constants.IDB.STORE);
+
+/**
+ * Adds a URL to IndexedDB, along with the current timestamp.
+ *
+ * If the request has a body, that body will be used as the URL's search
+ * parameters when saving the URL to IndexedDB.
+ *
+ * If no `time` parameter is provided, Date.now() will be used.
+ *
+ * @private
+ * @param {Request} request
+*  @param {Number} [time]
+ * @return {Promise.<T>} A promise that resolves when IndexedDB is updated.
+ */
+export default (request, time) => {
+  const url = new URL(request.url);
+  return request.text().then((body) => {
+    // If there's a request body, then use it as the URL's search value.
+    // This is most likely because the original request was an HTTP POST
+    // that uses the beacon transport.
+    if (body) {
+      url.search = body;
+    }
+
+    return idbHelper.put(url.toString(), time || Date.now());
+  });
+};

--- a/packages/sw-offline-google-analytics/src/lib/replay-queued-requests.js
+++ b/packages/sw-offline-google-analytics/src/lib/replay-queued-requests.js
@@ -1,0 +1,92 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env worker, serviceworker */
+
+import IDBHelper from '../../../../lib/idb-helper.js';
+import constants from './constants.js';
+
+const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+  constants.IDB.STORE);
+
+/**
+ * Replays all the queued requests found in IndexedDB, by calling fetch()
+ * with an additional parameter indicating the offset from the original time.
+ *
+ * Returns a promise that resolves when the replaying is complete.
+ *
+ * @private
+ * @param {Object=}   config Optional configuration arguments.
+ * @param {Object=}   config.parameterOverrides Optional
+ *                    [Measurement Protocol parameters](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters),
+ *                    expressed as key/value pairs, to be added to replayed
+ *                    Google Analytics requests. This can be used to, e.g., set
+ *                    a custom dimension indicating that the request was
+ *                    replayed.
+ * @param {Function=} config.hitFilter Optional
+ *                    A function that allows you to modify the hit parameters
+ *                    prior to replaying the hit. The function is invoked with
+ *                    the original hit's URLSearchParams object as its only
+ *                    argument. To abort the hit and prevent it from being
+ *                    replayed, throw an error.
+ * @return {Promise.<T>}
+ */
+ export default (config) => {
+  config = config || {};
+
+  return idbHelper.getAllKeys().then((urls) => {
+    return Promise.all(urls.map((url) => {
+      return idbHelper.get(url).then((hitTime) => {
+        const queueTime = Date.now() - hitTime;
+        const newUrl = new URL(url);
+
+        // Do not attempt to replay hits that are too old.
+        if (queueTime > constants.STOP_RETRYING_AFTER) {
+          return;
+        }
+
+        // Do not attempt to replay hits in browsers without
+        // URLSearchParams support.
+        if (!('searchParams' in newUrl)) {
+          return;
+        }
+
+        let parameterOverrides = config.parameterOverrides || {};
+        parameterOverrides.qt = queueTime;
+
+        // Call sort() on the keys so that there's a reliable order of calls
+        // to searchParams.set(). This isn't important in terms of
+        // functionality, but it will make testing easier, since the
+        // URL serialization depends on the order in which .set() is called.
+        Object.keys(parameterOverrides).sort().forEach((parameter) => {
+          newUrl.searchParams.set(parameter, parameterOverrides[parameter]);
+        });
+
+        // If the hitFilter config option was passed and is a function,
+        // invoke it with searchParams as its argument allowing the function
+        // to modify the hit prior to sending it. The function can also
+        // throw an error to abort the hit if needed.
+        let hitFilter = config.hitFilter;
+        if (typeof hitFilter === 'function') {
+          try {
+            hitFilter(newUrl.searchParams);
+          } catch (err) {
+            return;
+          }
+        }
+
+        return fetch(newUrl.toString());
+      }).then(() => idbHelper.delete(url));
+    }));
+  });
+};

--- a/packages/sw-offline-google-analytics/test/.eslintrc
+++ b/packages/sw-offline-google-analytics/test/.eslintrc
@@ -3,7 +3,5 @@
     "no-invalid-this": 0,
     "no-console": 0,
     "valid-jsdoc": 0,
-    "no-native-reassign": 0,
-    "no-global-assign": 0
   }
 }

--- a/packages/sw-offline-google-analytics/test/.eslintrc
+++ b/packages/sw-offline-google-analytics/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-invalid-this": 0,
+    "no-console": 0,
+    "valid-jsdoc": 0,
+    "no-native-reassign": 0
+  }
+}

--- a/packages/sw-offline-google-analytics/test/.eslintrc
+++ b/packages/sw-offline-google-analytics/test/.eslintrc
@@ -3,6 +3,7 @@
     "no-invalid-this": 0,
     "no-console": 0,
     "valid-jsdoc": 0,
-    "no-native-reassign": 0
+    "no-native-reassign": 0,
+    "no-global-assign": 0
   }
 }

--- a/packages/sw-offline-google-analytics/test/automated-suite.js
+++ b/packages/sw-offline-google-analytics/test/automated-suite.js
@@ -43,7 +43,7 @@ const configureTestSuite = function(browser) {
     // Set up the web server before running any tests in this suite.
     before(function() {
       return testServer.startServer('.').then((portNumber) => {
-        baseTestUrl = `http://localhost:${portNumber}/projects/sw-offline-google-analytics/test/`;
+        baseTestUrl = `http://localhost:${portNumber}/packages/sw-offline-google-analytics/test/`;
       });
     });
 

--- a/packages/sw-offline-google-analytics/test/automated-suite.js
+++ b/packages/sw-offline-google-analytics/test/automated-suite.js
@@ -1,0 +1,102 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+'use strict';
+
+/* eslint-env node, mocha, browser, serviceworker */
+/* eslint-disable max-len, no-unused-expressions */
+
+// These tests make use of selenium-webdriver. You can find the relevant
+// documentation here: http://selenium.googlecode.com/git/docs/api/javascript/index.html
+
+const seleniumAssistant = require('selenium-assistant');
+const swTestingHelpers = require('sw-testing-helpers');
+const testServer = new swTestingHelpers.TestServer();
+
+// Ensure the selenium drivers are added Node scripts path.
+require('geckodriver');
+require('chromedriver');
+require('operadriver');
+
+const TIMEOUT = 10 * 1000;
+
+const configureTestSuite = function(browser) {
+  let globalDriverReference = null;
+  let baseTestUrl;
+
+  describe(`sw-offline-google-analytics Test Suite with (${browser.getPrettyName()} - ${browser.getVersionNumber()})`, function() {
+    this.timeout(TIMEOUT);
+
+    // Set up the web server before running any tests in this suite.
+    before(function() {
+      return testServer.startServer('.').then((portNumber) => {
+        baseTestUrl = `http://localhost:${portNumber}/projects/sw-offline-google-analytics/test/`;
+      });
+    });
+
+    // Kill the web server once all tests are complete.
+    after(function() {
+      return seleniumAssistant.killWebDriver(globalDriverReference)
+      .then(() => {
+        return testServer.killServer();
+      });
+    });
+
+    it('should pass all tests', function() {
+      return browser.getSeleniumDriver()
+      .then((driver) => {
+        globalDriverReference = driver;
+        globalDriverReference.manage().timeouts().setScriptTimeout(TIMEOUT);
+      })
+      .then(() => {
+        return swTestingHelpers.mochaUtils.startWebDriverMochaTests(
+          browser.getPrettyName(),
+          globalDriverReference,
+          `${baseTestUrl}unit/`
+        );
+      })
+      .then((testResults) => {
+        if (testResults.failed.length > 0) {
+          const errorMessage = swTestingHelpers.mochaUtils.prettyPrintErrors(
+            browser.prettyName,
+            testResults
+          );
+
+          throw new Error(errorMessage);
+        }
+      });
+    });
+  });
+};
+
+seleniumAssistant.getAvailableBrowsers().forEach(function(browser) {
+  // Blackliist browsers here if needed.
+  if (browser.getSeleniumBrowserId() === 'opera' && browser.getVersionNumber() === 41) {
+    console.warn('Skipping Opera version 41 due to operadriver error.');
+    return;
+  }
+
+  switch (browser.getSeleniumBrowserId()) {
+    case 'chrome':
+    case 'firefox':
+    case 'opera':
+      configureTestSuite(browser);
+      break;
+    default:
+      console.warn(`Skipping ${browser.getPrettyName()}.`);
+      break;
+  }
+});

--- a/packages/sw-offline-google-analytics/test/unit/enqueue-request.js
+++ b/packages/sw-offline-google-analytics/test/unit/enqueue-request.js
@@ -1,0 +1,45 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env mocha, browser */
+/* global chai, goog */
+
+'use strict';
+
+describe('enqueue-request', () => {
+  const enqueueRequest = goog.offlineGoogleAnalytics.test.enqueueRequest;
+  const constants = goog.offlineGoogleAnalytics.test.constants;
+  const IDBHelper = goog.offlineGoogleAnalytics.test.IDBHelper;
+
+  const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+    constants.IDB.STORE);
+
+  it('should write to IndexedDB', () => {
+    const url = 'https://enqueue-request.com/?random=' + Math.random();
+    const request = new Request(url);
+    return enqueueRequest(request)
+      .then(() => idbHelper.getAllKeys())
+      .then((keys) => chai.expect(keys).to.include(url));
+  });
+
+  it('should use the request body, when present, in the IndexedDB key', () => {
+    const baseUrl = 'https://enqueue-request.com/';
+    const body = 'random=' + Math.random();
+    const url = `${baseUrl}?${body}`;
+
+    const request = new Request(url, {method: 'POST', body});
+    return enqueueRequest(request)
+      .then(() => idbHelper.getAllKeys())
+      .then((keys) => chai.expect(keys).to.include(url));
+  });
+});

--- a/packages/sw-offline-google-analytics/test/unit/index.html
+++ b/packages/sw-offline-google-analytics/test/unit/index.html
@@ -38,6 +38,7 @@
     <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
     <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
     <script src="/node_modules/mockdate/src/mockdate.js"></script>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
 
     <script src="/packages/sw-offline-google-analytics/build/test/constants.js"></script>
     <script src="/packages/sw-offline-google-analytics/build/test/idb-helper.js"></script>

--- a/packages/sw-offline-google-analytics/test/unit/index.html
+++ b/packages/sw-offline-google-analytics/test/unit/index.html
@@ -1,0 +1,79 @@
+<!--
+  Copyright 2016 Google Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>SW Toolbox Tests</title>
+    <link href="/node_modules/mocha/mocha.css" rel="stylesheet" />
+
+    <!--
+      iframes are used to manage service worker scoping.
+      This will hide them and stop the page from jumping around
+    -->
+    <style>
+      iframe {
+        width: 0;
+        height: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/mocha/mocha.js"></script>
+
+    <!-- sw-testing-helpers -->
+    <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
+    <script src="/node_modules/mockdate/src/mockdate.js"></script>
+
+    <script src="/packages/sw-offline-google-analytics/build/test/constants.js"></script>
+    <script src="/packages/sw-offline-google-analytics/build/test/idb-helper.js"></script>
+    <script src="/packages/sw-offline-google-analytics/build/test/replay-queued-requests.js"></script>
+    <script src="/packages/sw-offline-google-analytics/build/test/enqueue-request.js"></script>
+
+    <!--
+      Timeout is extended to ensure tests for max-cache-age
+      have enough time to complete
+    -->
+    <script>mocha.setup({
+      ui: 'bdd',
+      timeout: 10000
+    })</script>
+
+    <!-- In browser test scripts should be added to the page here-->
+
+    <script src="replay-queued-requests.js"></script>
+    <script src="enqueue-request.js"></script>
+
+    <script>
+      (function() {
+        // This make browsers without a service worker pass tests by
+        // bypassing the tests altogether.
+        // This is desirable to allow travis to run tests in all browsers
+        // regardless of support or not and perform tests when the browser
+        // starts to support service workers.
+        if (!('serviceWorker' in navigator)) {
+          publishTestResults();
+          return;
+        }
+
+        window.goog.mochaUtils.startInBrowserMochaTests().then(results => {
+          window.testsuite = results;
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/sw-offline-google-analytics/test/unit/replay-queued-requests.js
+++ b/packages/sw-offline-google-analytics/test/unit/replay-queued-requests.js
@@ -1,0 +1,132 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/* eslint-env mocha, browser */
+/* global chai, goog, fetch, MockDate */
+
+'use strict';
+
+describe('replay-queued-requests', () => {
+  const constants = goog.offlineGoogleAnalytics.test.constants;
+  const enqueueRequest = goog.offlineGoogleAnalytics.test.enqueueRequest;
+  const replayRequests = goog.offlineGoogleAnalytics.test.replayRequests;
+  const IDBHelper = goog.offlineGoogleAnalytics.test.IDBHelper;
+
+  const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
+     constants.IDB.STORE);
+
+  let fetchedUrls = [];
+  const urlPrefix = 'https://replay-queued-requests.com/';
+  // An arbitrary, but valid, timestamp in milliseconds.
+  const initialTimestamp = 1470405670000;
+  // A 1000 millisecond offset.
+  const timestampOffset = 1000;
+  const originalFetch = window.fetch;
+
+  beforeEach(function() {
+    MockDate.set(initialTimestamp + timestampOffset);
+    fetchedUrls = [];
+    fetch = (requestUrl) => {
+      const regex = /^https:\/\/replay-queued-requests.com\//g;
+      if (regex.test(requestUrl)) {
+        fetchedUrls.push(requestUrl);
+      }
+    };
+  });
+
+  afterEach(function() {
+    fetch = originalFetch;
+    MockDate.reset();
+  });
+
+  const testLogic = (initialUrls, expectedUrls, time, opts) => {
+    return Promise.all(initialUrls.map((url) => {
+      return enqueueRequest(new Request(url), time);
+    }))
+    .then(() => replayRequests(opts))
+    .then(() => chai.expect(fetchedUrls).to.deep.equal(expectedUrls))
+    .then(() => idbHelper.getAllKeys())
+    .then((keys) => chai.expect(keys.length).to.equal(0));
+  };
+
+  it('should replay queued requests', () => {
+    const urls = ['one', 'two?three=4'].map((suffix) => urlPrefix + suffix);
+    const time = initialTimestamp;
+    const urlsWithQt = urls.map((url) => {
+      const newUrl = new URL(url);
+      newUrl.searchParams.set('qt', timestampOffset);
+      return newUrl.toString();
+    });
+
+    return testLogic(urls, urlsWithQt, time);
+  });
+
+  it('should replay queued requests with parameters overrides', () => {
+    const urls = ['one', 'two?three=4'].map((suffix) => urlPrefix + suffix);
+    const time = initialTimestamp;
+    const parameterOverrides = {
+      three: 5,
+      four: 'six',
+      qt: timestampOffset,
+    };
+    const urlsWithParameterOverrides = urls.map((url) => {
+      const newUrl = new URL(url);
+      Object.keys(parameterOverrides).sort().forEach((parameter) => {
+        newUrl.searchParams.set(parameter, parameterOverrides[parameter]);
+      });
+      return newUrl.toString();
+    });
+
+    return testLogic(urls, urlsWithParameterOverrides, time,
+      {parameterOverrides});
+  });
+
+  it('should replay queued requests with a hit filter', () => {
+    const urls = ['one', 'two?three=4'].map((suffix) => urlPrefix + suffix);
+    const time = initialTimestamp;
+    const hitFilter = (searchParams) => {
+      const qt = searchParams.get('qt');
+      searchParams.set('cm1', qt);
+    };
+    const urlsWithHitFilterApplied = urls.map((url) => {
+      const newUrl = new URL(url);
+      newUrl.searchParams.set('qt', timestampOffset);
+      newUrl.searchParams.set('cm1', timestampOffset);
+      return newUrl.toString();
+    });
+
+    return testLogic(urls, urlsWithHitFilterApplied, time,
+      {hitFilter});
+  });
+
+  it('should not a replay queued requests when hit filter throws', () => {
+    const urls = ['one', 'two?three=4'].map((suffix) => urlPrefix + suffix);
+    const time = initialTimestamp;
+    const hitFilter = (searchParams) => {
+      const qt = searchParams.get('qt');
+      searchParams.set('cm1', qt);
+      if (searchParams.get('three') === '4') {
+        throw new Error('abort!');
+      }
+    };
+    const urlsWithHitFilterApplied = urls.slice(0, 1).map((url) => {
+      const newUrl = new URL(url);
+      newUrl.searchParams.set('qt', timestampOffset);
+      newUrl.searchParams.set('cm1', timestampOffset);
+      return newUrl.toString();
+    });
+
+    return testLogic(urls, urlsWithHitFilterApplied, time,
+      {hitFilter});
+  });
+});

--- a/packages/sw-offline-google-analytics/test/unit/replay-queued-requests.js
+++ b/packages/sw-offline-google-analytics/test/unit/replay-queued-requests.js
@@ -12,7 +12,7 @@
  */
 
 /* eslint-env mocha, browser */
-/* global chai, goog, fetch, MockDate */
+/* global chai, goog, MockDate, sinon */
 
 'use strict';
 
@@ -31,21 +31,21 @@ describe('replay-queued-requests', () => {
   const initialTimestamp = 1470405670000;
   // A 1000 millisecond offset.
   const timestampOffset = 1000;
-  const originalFetch = window.fetch;
+  let fetchStub;
 
   beforeEach(function() {
     MockDate.set(initialTimestamp + timestampOffset);
     fetchedUrls = [];
-    fetch = (requestUrl) => {
+    fetchStub = sinon.stub(window, 'fetch', (requestUrl) => {
       const regex = /^https:\/\/replay-queued-requests.com\//g;
       if (regex.test(requestUrl)) {
         fetchedUrls.push(requestUrl);
       }
-    };
+    });
   });
 
   afterEach(function() {
-    fetch = originalFetch;
+    fetchStub.restore();
     MockDate.reset();
   });
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani

This adds the offline-analytics back in.

The major thing to change was the tests.

Previously everything was run through browserify. I've switched to include appropriate files in the HTML page directly rather than require them in and I've built the tested files at build time rather than in the test itself.

The tested files are built into `build/test/` in sw-offline-google-analytics and I've added that directory to npmignore.