### PR TITLE
Extending tests for precaching module to ensure different scenarios a…

### DIFF
--- a/packages/sw-precaching/src/lib/error-factory.js
+++ b/packages/sw-precaching/src/lib/error-factory.js
@@ -21,6 +21,11 @@ const errors = {
     `string with revision info in the path or an object with path and ` +
     `revision and parameters.`,
   'bad-cache-bust': `The cache bust parameter must be a boolean.`,
+  'duplicate-entry-diff-revisions': `An attempt was made to cache the same ` +
+    `path twice with each having different revisions. This is not supported.`,
+  'request-not-cached': `A request failed the criteria to be cached. By ` +
+    `default, only responses with 'response.ok = true' or opaque responses ` +
+    `are cached.`,
 };
 
 export default new ErrorFactory(errors);

--- a/packages/sw-precaching/test/browser-unit/data/duplicate-entries/duplicate-entries-sw.js
+++ b/packages/sw-precaching/test/browser-unit/data/duplicate-entries/duplicate-entries-sw.js
@@ -1,0 +1,28 @@
+/* global goog, sinon */
+importScripts('/packages/sw-precaching/test/browser-unit/data/test-data.js');
+importScripts('/node_modules/sinon/pkg/sinon.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
+importScripts('/packages/sw-precaching/test/browser-unit/data/skip-and-claim.js');
+
+let requestsMade = [];
+
+sinon.stub(self, 'fetch', (requestUrl) => {
+  requestsMade.push(requestUrl);
+  return Promise.resolve(new Response());
+});
+
+const revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
+goog.__TEST_DATA['duplicate-entries'].forEach((entries) => {
+  revisionedCacheManager.cache({
+    revisionedFiles: entries,
+  });
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url === `${location.origin}/__api/get-requests-made/`) {
+    return event.respondWith(
+      new Response(JSON.stringify(requestsMade))
+    );
+  }
+  event.respondWith(caches.match(event.request));
+});

--- a/packages/sw-precaching/test/browser-unit/data/response-types/404-sw.js
+++ b/packages/sw-precaching/test/browser-unit/data/response-types/404-sw.js
@@ -1,0 +1,9 @@
+/* global goog */
+importScripts('/packages/sw-precaching/test/browser-unit/data/test-data.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
+importScripts('/packages/sw-precaching/test/browser-unit/data/skip-and-claim.js');
+
+const revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
+revisionedCacheManager.cache({
+  revisionedFiles: goog.__TEST_DATA['404'],
+});

--- a/packages/sw-precaching/test/browser-unit/data/response-types/opaque-sw.js
+++ b/packages/sw-precaching/test/browser-unit/data/response-types/opaque-sw.js
@@ -1,0 +1,13 @@
+/* global goog */
+importScripts('/packages/sw-precaching/test/browser-unit/data/test-data.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
+importScripts('/packages/sw-precaching/test/browser-unit/data/skip-and-claim.js');
+
+const revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
+revisionedCacheManager.cache({
+  revisionedFiles: goog.__TEST_DATA['opaque'],
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(caches.match(event.request));
+});

--- a/packages/sw-precaching/test/browser-unit/data/test-data.js
+++ b/packages/sw-precaching/test/browser-unit/data/test-data.js
@@ -50,4 +50,28 @@ self.goog.__TEST_DATA = {
     'step-1': EXAMPLE_REVISIONED_FILES_SET_1_STEP_1,
     'step-2': EXAMPLE_REVISIONED_FILES_SET_1_STEP_2,
   },
+  'duplicate-entries': [
+    [
+      '/__echo/date/1.1234.txt',
+      '/__echo/date/2.1234.txt',
+      '/__echo/date/3.1234.txt',
+      '/__echo/date/4.1234.txt',
+    ],
+    [
+      '/__echo/date/2.1234.txt',
+      '/__echo/date/4.1234.txt',
+      '/__echo/date/5.1234.txt',
+    ],
+    [
+      '/__echo/date/1.1234.txt',
+      '/__echo/date/3.1234.txt',
+      '/__echo/date/6.1234.txt',
+    ],
+  ],
+  '404': [
+    '/__test/404/',
+  ],
+  'opaque': [
+    `${secondaryServer}/__echo/date/hello.txt`,
+  ],
 };

--- a/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
@@ -17,12 +17,13 @@ mocha.setup({
 describe('Test RevisionedCacheManager', function() {
   let revisionedCacheManager;
 
-  before(function() {
+  beforeEach(function() {
     revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
   });
 
-  after(function() {
+  afterEach(function() {
     revisionedCacheManager._close();
+    revisionedCacheManager = null;
   });
 
   const badRevisionFileInputs = [
@@ -161,5 +162,22 @@ describe('Test RevisionedCacheManager', function() {
     it(`should be able to handle good cache input '${JSON.stringify(goodInput)}'`, function() {
       revisionedCacheManager.cache({revisionedFiles: [goodInput]});
     });
+  });
+
+  it('should throw error when precaching the same path but different revision', function() {
+    const TEST_PATH = '/__echo/date/hello.txt';
+    let thrownError = null;
+    try {
+      revisionedCacheManager.cache({revisionedFiles: [
+        {path: TEST_PATH, revision: '1234'},
+      ]});
+      revisionedCacheManager.cache({revisionedFiles: [
+        {path: TEST_PATH, revision: '5678'},
+      ]});
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    thrownError.name.should.equal('duplicate-entry-diff-revisions');
   });
 });

--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -39,10 +39,16 @@ class ServerInstance {
       res.send(`${req.params.file}-${Date.now()}`);
     });
 
-    this._app.get('/__echo/date-with-cors/:file', function(req, res) {
+    this._app.all('/__echo/date-with-cors/:file', function(req, res) {
+      res.setHeader('Access-Control-Allow-Methods',
+        'POST, GET, PUT, DELETE, OPTIONS');
       res.setHeader('Cache-Control', 'max-age=' + (24 * 60 * 60));
       res.setHeader('Access-Control-Allow-Origin', '*');
       res.send(`${req.params.file}-${Date.now()}`);
+    });
+
+    this._app.get('/__test/404/', function(req, res) {
+      res.status(404).send('404');
     });
   }
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

This adds tests to cover the following scenarios:

- Duplicate entries are only cached onces
- Duplicate entries with the same path but different revisions throw an error
- 404 URLs aren't cached by default (Should this be extended to a range of status codes?
- CORs and Non-CORs requests are cached by default.

This is somewhat in prep for #78 where we'll introduce a way to override the default behavior. For now its response.ok || response.type === 'opaque' only.