### PR TITLE
Precaching Rejig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,24 @@ sudo: required
 dist: trusty
 language: node_js
 
+cache:
+  directories:
+    - node_modules
+
 node_js:
   - 'stable'
+
+env:
+  - PROJECT="sw-appcache-behavior"
+  - PROJECT="sw-background-sync-queue"
+  - PROJECT="sw-broadcast-cache-update"
+  - PROJECT="sw-cache-expiration"
+  - PROJECT="sw-cli"
+  - PROJECT="sw-lib"
+  - PROJECT="sw-offline-google-analytics"
+  - PROJECT="sw-precaching"
+  - PROJECT="sw-routing"
+  - PROJECT="sw-runtime-caching"
 
 # Read more here: https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
 before_script:
@@ -12,6 +28,6 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - gulp lint
-  - gulp build
-  - gulp test
+  - gulp lint --project "${PROJECT}"
+  - gulp build --project "${PROJECT}"
+  - gulp test --project "${PROJECT}"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
 <!-- To make changes, edit templates/README.hbs, not README.md! -->
 [![Build Status][travis-image]][travis-url]
+[![Dependency Status][dependency-image]][dependency-url]
+[![Dev Dependency Status][dev-dependency-image]][dev-dependency-url]
 
-# Service Worker Framework
+# SW Helpers
 
 ## The Libraries
+### sw-appcache-behavior
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-appcache-behavior%22)][travis-url]
+
+A service worker implementation of the behavior defined in a page&#x27;s App Cache manifest.
+
+**Install**: `npm install --save-dev sw-appcache-behavior`
+
+**Learn More**: [About](packages/sw-appcache-behavior) •
+                [Demo](packages/sw-appcache-behavior#demo) •
+                [API](packages/sw-appcache-behavior#api)
+
+### sw-background-sync-queue
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-background-sync-queue%22)][travis-url]
+
+A service worker implementation of the a queue which is triggered by the background sync event.
+
+**Install**: `npm install --save-dev sw-background-sync-queue`
+
+**Learn More**: [About](packages/sw-background-sync-queue) •
+                [Demo](packages/sw-background-sync-queue#demo) •
+                [API](packages/sw-background-sync-queue#api)
+
 ### sw-broadcast-cache-update
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-broadcast-cache-update%22)][travis-url]
+
 A helper library that uses the Broadcast Channel API to announce when two Response objects differ.
 
 **Install**: `npm install --save-dev sw-broadcast-cache-update`
@@ -14,6 +43,9 @@ A helper library that uses the Broadcast Channel API to announce when two Respon
                 [API](packages/sw-broadcast-cache-update#api)
 
 ### sw-cache-expiration
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-cache-expiration%22)][travis-url]
+
 This library is still a work in progress and is not functional.
 
 **Install**: `npm install --save-dev sw-cache-expiration`
@@ -22,7 +54,34 @@ This library is still a work in progress and is not functional.
                 [Demo](packages/sw-cache-expiration#demo) •
                 [API](packages/sw-cache-expiration#api)
 
+### sw-lib
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-lib%22)][travis-url]
+
+A service worker library to make managing fetch requests and caching as easy as possible.
+
+**Install**: `npm install --save-dev sw-lib`
+
+**Learn More**: [About](packages/sw-lib) •
+                [Demo](packages/sw-lib#demo) •
+                [API](packages/sw-lib#api)
+
+### sw-offline-google-analytics
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-offline-google-analytics%22)][travis-url]
+
+A service worker helper library to retry offline Google Analytics requests when a connection is available.
+
+**Install**: `npm install --save-dev sw-offline-google-analytics`
+
+**Learn More**: [About](packages/sw-offline-google-analytics) •
+                [Demo](packages/sw-offline-google-analytics#demo) •
+                [API](packages/sw-offline-google-analytics#api)
+
 ### sw-precaching
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-precaching%22)][travis-url]
+
 This library is still a work in progress and is not functional.
 
 **Install**: `npm install --save-dev sw-precaching`
@@ -32,6 +91,9 @@ This library is still a work in progress and is not functional.
                 [API](packages/sw-precaching#api)
 
 ### sw-routing
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-routing%22)][travis-url]
+
 A service worker helper library to route request URLs to handlers.
 
 **Install**: `npm install --save-dev sw-routing`
@@ -41,6 +103,9 @@ A service worker helper library to route request URLs to handlers.
                 [API](packages/sw-routing#api)
 
 ### sw-runtime-caching
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22sw-runtime-caching%22)][travis-url]
+
 A service worker helper library that implements various runtime caching strategies.
 
 **Install**: `npm install --save-dev sw-runtime-caching`
@@ -75,3 +140,7 @@ limitations under the License.
 [npm-image]: https://badge.fury.io/js/sw-helpers.svg
 [travis-url]: https://travis-ci.org/GoogleChrome/sw-helpers
 [travis-image]: https://travis-ci.org/GoogleChrome/sw-helpers.svg?branch=master
+[dependency-url]: https://david-dm.org/GoogleChrome/sw-helpers/
+[dependency-image]: https://david-dm.org/GoogleChrome/sw-helpers/dev-status.svg
+[dev-dependency-url]: https://david-dm.org/GoogleChrome/sw-helpers?type=dev
+[dev-dependency-image]: https://david-dm.org/GoogleChrome/sw-helpers/status.svg

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -15,6 +15,7 @@
 const seleniumAssistant = require('selenium-assistant');
 const gulp = require('gulp');
 const mocha = require('gulp-spawn-mocha');
+const glob = require('glob');
 
 gulp.task('download-browsers', function() {
   console.log('    Starting browser download.....');
@@ -36,7 +37,13 @@ gulp.task('test', ['download-browsers'], () => {
   if (global.cliOptions.grep) {
     mochaOptions.grep = global.cliOptions.grep;
   }
-  return gulp.src(`packages/${global.projectOrStar}/test/*.js`, {read: false})
+  const testGlob = `packages/${global.projectOrStar}/test/*.js`;
+  const testFiles = glob.sync(testGlob);
+  if (testFiles.length === 0) {
+    // Mocha fails when no tests are found so return early.
+    return;
+  }
+  return gulp.src(testGlob, {read: false})
     .pipe(mocha(mochaOptions))
     .once('error', (error) => {
       console.error(error);

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
     "sinon": "^1.17.6",
-    "sw-testing-helpers": "0.1.4"
+    "sw-testing-helpers": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-eslint": "^3.0.1",
     "gulp-header": "^1.8.8",
+    "gulp-if": "^2.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-rollup": "^2.5.1",
     "gulp-spawn-mocha": "^3.1.0",

--- a/packages/sw-appcache-behavior/build.js
+++ b/packages/sw-appcache-behavior/build.js
@@ -12,6 +12,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');
@@ -32,7 +33,7 @@ module.exports = () => {
           commonjs(),
         ],
       },
-      outputName: 'build/client-runtime.js',
+      buildPath: 'build/client-runtime.js',
       projectDir: __dirname,
     }),
     buildJSBundle({
@@ -49,7 +50,7 @@ module.exports = () => {
           commonjs(),
         ],
       },
-      outputName: 'build/appcache-behavior-import.js',
+      buildPath: 'build/appcache-behavior-import.js',
       projectDir: __dirname,
     }),
   ]);

--- a/packages/sw-background-sync-queue/build.js
+++ b/packages/sw-background-sync-queue/build.js
@@ -15,95 +15,82 @@
 
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');
+const pkg = require('./package.json');
 const resolve = require('rollup-plugin-node-resolve');
 const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/background-sync-queue.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'request-queue.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue.test.RequestQueue',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/request-queue.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'background-sync-queue.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue.test.BackgroundSyncQueue',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/background-sync-queue.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue.test.constants',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/constants.js',
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const mainModuleBuilds = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.backgroundSyncQueue').map(buildJSBundle);
+
+module.exports = () => Promise.all([
+  ...mainModuleBuilds,
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'request-queue.js'),
+      format: 'umd',
+      moduleName: 'goog.backgroundSyncQueue.test.RequestQueue',
+      plugins: [
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        rollupBabel({
+          plugins: ['transform-async-to-generator', 'external-helpers'],
+          exclude: 'node_modules/**',
+        }),
+        commonjs(),
+      ],
+    },
+    buildPath: 'build/test/request-queue.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'background-sync-queue.js'),
+      format: 'umd',
+      moduleName: 'goog.backgroundSyncQueue.test.BackgroundSyncQueue',
+      plugins: [
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        rollupBabel({
+          plugins: ['transform-async-to-generator', 'external-helpers'],
+          exclude: 'node_modules/**',
+        }),
+        commonjs(),
+      ],
+    },
+    buildPath: 'build/test/background-sync-queue.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
+      format: 'umd',
+      moduleName: 'goog.backgroundSyncQueue.test.constants',
+      plugins: [
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        rollupBabel({
+          plugins: ['transform-async-to-generator', 'external-helpers'],
+          exclude: 'node_modules/**',
+        }),
+        commonjs(),
+      ],
+    },
+    buildPath: 'build/test/constants.js',
+    projectDir: __dirname,
+  }),
+]);

--- a/packages/sw-background-sync-queue/package.json
+++ b/packages/sw-background-sync-queue/package.json
@@ -14,7 +14,7 @@
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",
   "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-background-sync-queue",
-  "main": "build/background-sync-queue.js",
+  "main": "build/background-sync-queue.min.js",
   "module": "build/background-sync-queue.min.mjs",
   "jsnext:main": "build/background-sync-queue.min.mjs"
 }

--- a/packages/sw-background-sync-queue/test/unit/index.html
+++ b/packages/sw-background-sync-queue/test/unit/index.html
@@ -35,8 +35,8 @@
     <script src="/node_modules/mocha/mocha.js"></script>
 
     <!-- sw-testing-helpers -->
-    <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
-    <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/mocha-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/sw-utils.js"></script>
     <script src="/node_modules/mockdate/src/mockdate.js"></script>
     <script src="/node_modules/sinon/pkg/sinon.js"></script>
     <script src="/packages/sw-background-sync-queue/build/test/constants.js"></script>

--- a/packages/sw-broadcast-cache-update/build.js
+++ b/packages/sw-broadcast-cache-update/build.js
@@ -12,28 +12,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const path = require('path');
-const {buildJSBundle} = require('../../build-utils');
-const pkg = require('./package.json');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.broadcastCacheUpdate',
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
+
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.broadcastCacheUpdate');
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cache-expiration/build.js
+++ b/packages/sw-cache-expiration/build.js
@@ -13,55 +13,12 @@
  limitations under the License.
 */
 
-const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
 const pkg = require('./package.json');
-const resolve = require('rollup-plugin-node-resolve');
-const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.cacheExpiration',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.cacheExpiration');
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cli/.eslintrc
+++ b/packages/sw-cli/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module",
+  }
+}

--- a/packages/sw-cli/build.js
+++ b/packages/sw-cli/build.js
@@ -12,56 +12,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
+
 const pkg = require('./package.json');
-const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.swcli');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.swcli',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cli/build.js
+++ b/packages/sw-cli/build.js
@@ -1,0 +1,67 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+const resolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+const path = require('path');
+const pkg = require('./package.json');
+const rollupBabel = require('rollup-plugin-babel');
+const {buildJSBundle} = require('../../build-utils');
+
+
+module.exports = () => {
+  return Promise.all([
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, 'src', 'index.js'),
+        format: 'umd',
+        moduleName: 'goog.swcli',
+        plugins: [
+          rollupBabel({
+            plugins: ['transform-async-to-generator', 'external-helpers'],
+            exclude: 'node_modules/**',
+          }),
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: pkg.main,
+      projectDir: __dirname,
+    }),
+    buildJSBundle({
+      rollupConfig: {
+        entry: path.join(__dirname, 'src', 'index.js'),
+        format: 'es',
+        plugins: [
+          rollupBabel({
+            plugins: ['transform-async-to-generator', 'external-helpers'],
+            exclude: 'node_modules/**',
+          }),
+          resolve({
+            jsnext: true,
+            main: true,
+            browser: true,
+          }),
+          commonjs(),
+        ],
+      },
+      outputName: pkg['jsnext:main'],
+      projectDir: __dirname,
+    }),
+  ]);
+};

--- a/packages/sw-cli/package.json
+++ b/packages/sw-cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "sw-lib",
+  "private": true,
+  "version": "0.0.5",
+  "description": "A CLI tool to generate a service worker and file manifest making use of the sw-lib module.",
+  "keywords": [
+    "sw-fw",
+    "service worker",
+    "caching",
+    "fetch requests",
+    "offline",
+    "cli"
+  ],
+  "main": "build/sw-cli.min.js",
+  "module": "build/sw-cli.min.mjs",
+  "jsnext:main": "build/sw-cli.min.mjs",
+  "bin": {
+    "sw-cli": "src/bin/index.js"
+  },
+  "engines": {
+    "node" : ">=4.0.0"
+  },
+  "author": "Google's Web DevRel Team",
+  "license": "Apache-2.0",
+  "repository": "googlechrome/sw-helpers",
+  "bugs": "https://github.com/googlechrome/sw-helpers/issues",
+  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-cli",
+  "dependencies": {
+    "chalk": "^1.1.3",
+    "minimist": "^1.2.0"
+  }
+}

--- a/packages/sw-cli/src/bin/index.js
+++ b/packages/sw-cli/src/bin/index.js
@@ -1,0 +1,21 @@
+#! /usr/bin/env node
+
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+'use strict';
+
+const CLI = require('../cli/index.js');
+new CLI().argv(process.argv.slice(2));

--- a/packages/sw-cli/src/cli/cli-help.txt
+++ b/packages/sw-cli/src/cli/cli-help.txt
@@ -1,0 +1,14 @@
+sw-cli
+
+Usage:
+    sw-cli [command] [options]
+
+Commands:
+
+    generate-sw
+    build-file-manifest
+
+Options
+
+    -h --help               Show this help text.
+    -v --version            Show current version of sw-cli

--- a/packages/sw-cli/src/cli/index.js
+++ b/packages/sw-cli/src/cli/index.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+
+const logHelper = require('../lib/log-helper');
+const pkg = require('../../package.json');
+
+/**
+ * This class is a wrapper to make test easier. This is used by
+ * ./bin/index.js to pass in the args when the CLI is used.
+ */
+class SWCli {
+  /**
+   * @private
+   * This is a helper method that allows the test framework to call argv with
+   * arguments without worrying about running as an actual CLI.
+   * @param {Object} argv The value passed in via process.argv.
+   * @return {Promise} Promise is returned so testing framework knows when
+   * handling the request has finished.
+   */
+  argv(argv) {
+    const cliArgs = minimist(argv);
+    if (cliArgs._.length > 0) {
+      // We have a command
+      return this.handleCommand(cliArgs._[0], cliArgs._.splice(1), cliArgs)
+      .then(() => {
+        process.exit(0);
+      })
+      .catch(() => {
+        process.exit(1);
+      });
+    } else {
+      // we have a flag only request
+      return this.handleFlag(cliArgs)
+      .then(() => {
+        process.exit(0);
+      })
+      .catch(() => {
+        process.exit(1);
+      });
+    }
+  }
+
+  /**
+   * Prints the help text to the terminal.
+   */
+  printHelpText() {
+    const helpText = fs.readFileSync(
+      path.join(__dirname, 'cli-help.txt'), 'utf8');
+    logHelper.info(helpText);
+  }
+
+  /**
+   * If there is no command given to the CLI then the flags will be passed
+   * to this function in case a relevant action can be taken.
+   * @param {object} flags The available flags from the command line.
+   * @return {Promise} returns a promise once handled.
+   */
+  handleFlag(flags) {
+    let handled = false;
+    if (flags.h || flags.help) {
+      this.printHelpText();
+      handled = true;
+    }
+
+    if (flags.v || flags.version) {
+      logHelper.info(pkg.version);
+      handled = true;
+    }
+
+    if (handled) {
+      return Promise.resolve();
+    }
+
+    // This is a fallback
+    this.printHelpText();
+    return Promise.reject();
+  }
+
+  /**
+   * If a command is given in the command line args, this method will handle
+   * the appropriate action.
+   * @param {string} command The command name.
+   * @param {object} args The arguments given to this command.
+   * @param {object} flags The flags supplied with the command line.
+   * @return {Promise} A promise for the provided task.
+   */
+  handleCommand(command, args, flags) {
+    switch (command) {
+      case 'generate-sw':
+        return this.generateSW();
+      case 'build-file-manifest':
+        return this.buildFileManifest();
+      default:
+        logHelper.error(`Invlaid command given '${command}'`);
+        return Promise.reject();
+    }
+  }
+
+  /**
+   * This method will generate a working Service Worker with a file manifest.
+   * @return {Promise} The promise returned here will be used to exit the
+   * node process cleanly or not.
+   */
+  generateSW() {
+    // TODO: Generate SW
+    return Promise.resolve();
+  }
+
+  /**
+   * This method will generate the file manifest only.
+   * @return {Promise} The promise returned here will be used to exit the
+   * node process cleanly or not.
+   */
+  buildFileManifest() {
+    // TODO: Build File Manifest
+    return Promise.resolve();
+  }
+}
+
+module.exports = SWCli;

--- a/packages/sw-cli/src/index.js
+++ b/packages/sw-cli/src/index.js
@@ -1,0 +1,1 @@
+// This will be the logic that powers both module and CLI

--- a/packages/sw-cli/src/lib/log-helper.js
+++ b/packages/sw-cli/src/lib/log-helper.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+'use strict';
+
+/* eslint-disable no-console */
+
+const chalk = require('chalk');
+
+/**
+ * Log helper is just a wrapper around the console to print slightly
+ * nicer / colored messages and could be extended to filter based on log
+ * level.
+ */
+class LogHelper {
+  /**
+   * Print a warning message to the console (Colored yellow).
+   * @param {string} msg Message to print to the console
+   */
+  warn(msg) {
+    console.warn(chalk.yellow(msg));
+  }
+
+  /**
+   * Print an error message to the console (Colored red).
+   * @param {string} msg Message to print to the console
+   */
+  error(msg) {
+    if (msg.stack) {
+      console.error(chalk.red(msg.stack));
+    } else {
+      console.error(chalk.red(msg));
+    }
+  }
+
+  /**
+   * Print an info message to the console (Colored dim).
+   * @param {string} msg Message to print to the console
+   */
+  info(msg) {
+    console.log(chalk.dim(msg));
+  }
+}
+
+module.exports = new LogHelper();

--- a/packages/sw-cli/test/.eslintrc
+++ b/packages/sw-cli/test/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "no-console": 0,
+    "max-len": 0
+  }
+}

--- a/packages/sw-cli/test/cli-flags.js
+++ b/packages/sw-cli/test/cli-flags.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const pkg = require('../package.json');
+const CLI = require('../src/cli/index.js');
+
+require('chai').should();
+
+describe('Test CLI Flags', function() {
+  const originalExit = process.exit;
+
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  let consoleLogs = [];
+  let consoleWarns = [];
+  let consoleErrors = [];
+
+  let globalExitCode;
+
+  const startLogCapture = () => {
+    console.log = (string) => {
+      consoleLogs.push(string);
+    };
+    console.warn = (string) => {
+      consoleWarns.push(string);
+    };
+    console.error = (string) => {
+      consoleErrors.push(string);
+    };
+  };
+
+  const endLogCapture = () => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  };
+
+  beforeEach(function() {
+    consoleLogs = [];
+    consoleWarns = [];
+    consoleErrors = [];
+    globalExitCode = -1;
+
+    process.exit = (code) => {
+      globalExitCode = code;
+    };
+  });
+
+  afterEach(function() {
+    endLogCapture();
+
+    process.exit = originalExit;
+  });
+
+  const versionFlags = [
+    '-v',
+    '--version',
+  ];
+  versionFlags.forEach((versionFlag) => {
+    it(`should handle version flags: ${versionFlag}`, function() {
+      startLogCapture();
+      return new CLI().argv([versionFlag])
+      .then(() => {
+        endLogCapture();
+
+        globalExitCode.should.equal(0);
+
+        consoleLogs.length.should.equal(1);
+
+        consoleLogs[0].indexOf(pkg.version).should.not.equal(-1);
+      });
+    });
+  });
+
+  const helpFlags = [
+    '-h',
+    '--help',
+  ];
+  const helpText = fs.readFileSync(path.join(__dirname, '..', 'src', 'cli', 'cli-help.txt'), 'utf8');
+  helpFlags.forEach((helpFlag) => {
+    it(`should handle version flags: ${helpFlag}`, function() {
+      startLogCapture();
+      return new CLI().argv([helpFlag])
+      .then(() => {
+        endLogCapture();
+
+        globalExitCode.should.equal(0);
+
+        consoleLogs.length.should.equal(1);
+
+        consoleLogs[0].indexOf(helpText).should.not.equal(-1);
+      });
+    });
+  });
+});

--- a/packages/sw-lib/build.js
+++ b/packages/sw-lib/build.js
@@ -12,35 +12,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const rollupBabel = require('rollup-plugin-babel');
-const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
-const packageJson = require('./package.json');
-const {buildJSBundle} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.swlib',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: packageJson.main,
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
+
+const buildConfigs = generateBuildConfigs({
+  umd: pkg.main,
+}, __dirname, 'goog.swlib');
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-lib/test/automated-test-suite.js
+++ b/packages/sw-lib/test/automated-test-suite.js
@@ -21,7 +21,7 @@ require('chromedriver');
 require('operadriver');
 require('geckodriver');
 
-const RETRIES = 4;
+const RETRIES = 0;
 const TIMEOUT = 10 * 1000;
 
 describe('sw-lib Tests', function() {
@@ -69,25 +69,9 @@ describe('sw-lib Tests', function() {
           );
         })
         .then((testResults) => {
-          // Print test failues
-          const passedTests = testResults.passed;
-          const passedStrings = passedTests.map((test, i) => {
-            return `[Passed Test ${i + 1}]\n` +
-                   `    - ${test.parentTitle} > ${test.title}\n`;
-          });
-          const failedTests = testResults.failed;
-          const failedStrings = failedTests.map((test, i) => {
-            return `[Failed Test ${i + 1}]\n` +
-                   `    - ${test.parentTitle} > ${test.title}\n`;
-          });
-          console.log('-------------------------------------------');
-          if (passedTests.length > 0) {
-            console.log(passedStrings.join('\n'));
-          }
-          if (failedTests.length > 0) {
-            console.log(failedStrings.join('\n'));
-          }
-          console.log('---------------------------------------------------');
+          console.log(
+            swTestingHelpers.mochaUtils.prettyPrintResults(testResults)
+          );
 
           if (testResults.failed.length > 0) {
             throw new Error('Failing tests');

--- a/packages/sw-lib/test/automated-test-suite.js
+++ b/packages/sw-lib/test/automated-test-suite.js
@@ -69,13 +69,28 @@ describe('sw-lib Tests', function() {
           );
         })
         .then((testResults) => {
-          if (testResults.failed.length > 0) {
-            const errorMessage = swTestingHelpers.mochaUtils.prettyPrintErrors(
-              assistantDriver.getPrettyName(),
-              testResults
-            );
+          // Print test failues
+          const passedTests = testResults.passed;
+          const passedStrings = passedTests.map((test, i) => {
+            return `[Passed Test ${i + 1}]\n` +
+                   `    - ${test.parentTitle} > ${test.title}\n`;
+          });
+          const failedTests = testResults.failed;
+          const failedStrings = failedTests.map((test, i) => {
+            return `[Failed Test ${i + 1}]\n` +
+                   `    - ${test.parentTitle} > ${test.title}\n`;
+          });
+          console.log('-------------------------------------------');
+          if (passedTests.length > 0) {
+            console.log(passedStrings.join('\n'));
+          }
+          if (failedTests.length > 0) {
+            console.log(failedStrings.join('\n'));
+          }
+          console.log('---------------------------------------------------');
 
-            throw new Error(errorMessage);
+          if (testResults.failed.length > 0) {
+            throw new Error('Failing tests');
           }
         });
       });

--- a/packages/sw-lib/test/browser-unit/cache-revisioned-e2e.js
+++ b/packages/sw-lib/test/browser-unit/cache-revisioned-e2e.js
@@ -44,7 +44,7 @@ describe('sw-lib Test Revisioned Caching', function() {
         cachedResponses.forEach((cachedResponse) => {
           let desiredPath = assetAndHash;
           if (typeof assetAndHash !== 'string') {
-            desiredPath = assetAndHash.path;
+            desiredPath = assetAndHash.url;
           }
 
           if (cachedResponse.url.indexOf(desiredPath) !== -1) {
@@ -60,7 +60,7 @@ describe('sw-lib Test Revisioned Caching', function() {
       const promises = fileSet.map((assetAndHash) => {
         let url = assetAndHash;
         if (typeof assetAndHash === 'object') {
-          url = assetAndHash.path;
+          url = assetAndHash.url;
         }
 
         return iframe.contentWindow.fetch(url);
@@ -85,16 +85,16 @@ describe('sw-lib Test Revisioned Caching', function() {
   const compareCachedAssets = function(beforeData, afterData) {
     afterData.cacheList.forEach((afterAssetAndHash) => {
       if (typeof assetAndHash === 'string') {
-        afterAssetAndHash = {path: afterAssetAndHash, revision: afterAssetAndHash};
+        afterAssetAndHash = {url: afterAssetAndHash, revision: afterAssetAndHash};
       }
 
       let matchingBeforeAssetAndHash = null;
       beforeData.cacheList.forEach((beforeAssetAndHash) => {
         if (typeof beforeAssetAndHash === 'string') {
-          beforeAssetAndHash = {path: beforeAssetAndHash, revision: beforeAssetAndHash};
+          beforeAssetAndHash = {url: beforeAssetAndHash, revision: beforeAssetAndHash};
         }
 
-        if (beforeAssetAndHash.path === afterAssetAndHash.path) {
+        if (beforeAssetAndHash.url === afterAssetAndHash.url) {
           matchingBeforeAssetAndHash = beforeAssetAndHash;
         }
       });
@@ -103,7 +103,7 @@ describe('sw-lib Test Revisioned Caching', function() {
         return;
       }
 
-      let pathToCheck = new URL(afterAssetAndHash.path, location.origin).toString();
+      let pathToCheck = new URL(afterAssetAndHash.url, location.origin).toString();
 
       const beforeResponseBody = beforeData.cachedResponses[pathToCheck];
       const afterResponseBody = afterData.cachedResponses[pathToCheck];

--- a/packages/sw-lib/test/browser-unit/data/test-data.js
+++ b/packages/sw-lib/test/browser-unit/data/test-data.js
@@ -2,22 +2,22 @@ self.goog.__TEST_DATA['sw-lib'] = {
   'set-1': self.goog.__TEST_DATA['set-1']['step-1'],
   'set-2': [
     '/__echo/date/sw-lib-1.1234.txt',
-    {path: '/__echo/date/sw-lib-2.txt', revision: '1234'},
+    {url: '/__echo/date/sw-lib-2.txt', revision: '1234'},
   ],
   'set-3': [
     '/__echo/date/sw-lib-3.1234.txt',
-    {path: '/__echo/date/sw-lib-4.txt', revision: '1234'},
+    {url: '/__echo/date/sw-lib-4.txt', revision: '1234'},
   ],
   'set-4': [
     '/__echo/date/sw-lib-1.5678.txt',
-    {path: '/__echo/date/sw-lib-2.txt', revision: '5678'},
+    {url: '/__echo/date/sw-lib-2.txt', revision: '5678'},
   ],
   'set-5': [
     '/__echo/date/sw-lib-3.1234.txt',
-    {path: '/__echo/date/sw-lib-4.txt', revision: '1234'},
+    {url: '/__echo/date/sw-lib-4.txt', revision: '1234'},
   ],
   'set-6': [
     '/__echo/date/sw-lib-5.1234.txt',
-    {path: '/__echo/date/sw-lib-6.txt', revision: '1234'},
+    {url: '/__echo/date/sw-lib-6.txt', revision: '1234'},
   ],
 };

--- a/packages/sw-lib/test/browser-unit/index.html
+++ b/packages/sw-lib/test/browser-unit/index.html
@@ -35,8 +35,8 @@
     <script src="/node_modules/mocha/mocha.js"></script>
 
     <!-- sw-testing-helpers -->
-    <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
-    <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/mocha-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/sw-utils.js"></script>
     <script src="/node_modules/sinon/pkg/sinon.js"></script>
 
     <!--

--- a/packages/sw-lib/test/browser-unit/library-namespace.js
+++ b/packages/sw-lib/test/browser-unit/library-namespace.js
@@ -43,34 +43,16 @@ describe('Test Behaviors of Loading the Script', function() {
 
   it('should perform basic.js sw tests', function() {
     const serviceWorkerPath = 'sw-unit/basic.js';
-    return window.goog.mochaUtils.startServiceWorkerMochaTests(serviceWorkerPath)
-    .then((testResults) => {
-      if (testResults.failed.length > 0) {
-        const errorMessage = window.goog.mochaUtils.prettyPrintErrors(serviceWorkerPath, testResults);
-        throw new Error(errorMessage);
-      }
-    });
+    return window.goog.mochaUtils.registerServiceWorkerMochaTests(serviceWorkerPath);
   });
 
   it('should perform router.js sw tests', function() {
     const serviceWorkerPath = 'sw-unit/router.js';
-    return window.goog.mochaUtils.startServiceWorkerMochaTests(serviceWorkerPath)
-    .then((testResults) => {
-      if (testResults.failed.length > 0) {
-        const errorMessage = window.goog.mochaUtils.prettyPrintErrors(serviceWorkerPath, testResults);
-        throw new Error(errorMessage);
-      }
-    });
+    return window.goog.mochaUtils.registerServiceWorkerMochaTests(serviceWorkerPath);
   });
 
   it('should perform cache-revisioned-assets.js sw tests', function() {
     const serviceWorkerPath = 'sw-unit/cache-revisioned-assets.js';
-    return window.goog.mochaUtils.startServiceWorkerMochaTests(serviceWorkerPath)
-    .then((testResults) => {
-      if (testResults.failed.length > 0) {
-        const errorMessage = window.goog.mochaUtils.prettyPrintErrors(serviceWorkerPath, testResults);
-        throw new Error(errorMessage);
-      }
-    });
+    return window.goog.mochaUtils.registerServiceWorkerMochaTests(serviceWorkerPath);
   });
 });

--- a/packages/sw-lib/test/browser-unit/sw-unit/basic.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/basic.js
@@ -1,6 +1,6 @@
 importScripts('/node_modules/mocha/mocha.js');
 importScripts('/node_modules/chai/chai.js');
-importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
+importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
 
 importScripts('/packages/sw-lib/build/sw-lib.min.js');
 

--- a/packages/sw-lib/test/browser-unit/sw-unit/cache-revisioned-assets.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/cache-revisioned-assets.js
@@ -1,6 +1,6 @@
 importScripts('/node_modules/mocha/mocha.js');
 importScripts('/node_modules/chai/chai.js');
-importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
+importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
 
 importScripts('/packages/sw-lib/build/sw-lib.min.js');
 

--- a/packages/sw-lib/test/browser-unit/sw-unit/cache-revisioned-assets.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/cache-revisioned-assets.js
@@ -3,7 +3,6 @@ importScripts('/node_modules/chai/chai.js');
 importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
 
 importScripts('/packages/sw-lib/build/sw-lib.min.js');
-importScripts('/packages/sw-routing/build/sw-routing.min.js');
 
 /* global goog */
 

--- a/packages/sw-lib/test/browser-unit/sw-unit/cache-revisioned-assets.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/cache-revisioned-assets.js
@@ -63,21 +63,21 @@ describe('Test swlib.cacheRevisionedAssets', function() {
     const validAssets1 = [
       '/__echo/date/1.1234.txt',
       {
-        path: '/__echo/date/2.txt', revision: '1234',
+        url: '/__echo/date/2.txt', revision: '1234',
       },
       `${corsOrigin}/__echo/date/3.1234.txt`,
       {
-        path: `${corsOrigin}/__echo/date/4.txt`, revision: '1234',
+        url: `${corsOrigin}/__echo/date/4.txt`, revision: '1234',
       },
     ];
     const validAssets2 = [
       '/__echo/date/5.1234.txt',
       {
-        path: '/__echo/date/6.txt', revision: '1234',
+        url: '/__echo/date/6.txt', revision: '1234',
       },
       `${corsOrigin}/__echo/date/7.1234.txt`,
       {
-        path: `${corsOrigin}/__echo/date/8.txt`, revision: '1234',
+        url: `${corsOrigin}/__echo/date/8.txt`, revision: '1234',
       },
     ];
 

--- a/packages/sw-lib/test/browser-unit/sw-unit/router.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/router.js
@@ -1,6 +1,6 @@
 importScripts('/node_modules/mocha/mocha.js');
 importScripts('/node_modules/chai/chai.js');
-importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
+importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
 
 importScripts('/packages/sw-lib/build/sw-lib.min.js');
 

--- a/packages/sw-lib/test/browser-unit/sw-unit/router.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/router.js
@@ -3,7 +3,6 @@ importScripts('/node_modules/chai/chai.js');
 importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
 
 importScripts('/packages/sw-lib/build/sw-lib.min.js');
-importScripts('/packages/sw-routing/build/sw-routing.min.js');
 
 /* global goog */
 

--- a/packages/sw-offline-google-analytics/build.js
+++ b/packages/sw-offline-google-analytics/build.js
@@ -12,97 +12,70 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');
-const {buildJSBundle} = require('../../build-utils');
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/offline-google-analytics-import.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'enqueue-request.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.enqueueRequest',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/enqueue-request.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'replay-queued-requests.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.replayRequests',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/replay-queued-requests.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.constants',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/constants.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, '..', '..', 'lib', 'idb-helper.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.IDBHelper',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/idb-helper.js',
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const plugins = [
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  commonjs(),
+];
+
+const mainModuleBuilds = generateBuildConfigs({
+  umd: pkg.main,
+}, __dirname, 'goog.offlineGoogleAnalytics').map(buildJSBundle);
+
+module.exports = () => Promise.all([
+  ...mainModuleBuilds,
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'enqueue-request.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.enqueueRequest',
+      plugins,
+    },
+    buildPath: 'build/test/enqueue-request.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'replay-queued-requests.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.replayRequests',
+      plugins,
+    },
+    buildPath: 'build/test/replay-queued-requests.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.constants',
+      plugins,
+    },
+    buildPath: 'build/test/constants.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, '..', '..', 'lib', 'idb-helper.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.IDBHelper',
+      plugins,
+    },
+    buildPath: 'build/test/idb-helper.js',
+    projectDir: __dirname,
+  }),
+]);

--- a/packages/sw-offline-google-analytics/package.json
+++ b/packages/sw-offline-google-analytics/package.json
@@ -16,5 +16,6 @@
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",
-  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics"
+  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics",
+  "main": "build/offline-google-analytics-import.min.js"
 }

--- a/packages/sw-offline-google-analytics/test/unit/index.html
+++ b/packages/sw-offline-google-analytics/test/unit/index.html
@@ -35,8 +35,8 @@
     <script src="/node_modules/mocha/mocha.js"></script>
 
     <!-- sw-testing-helpers -->
-    <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
-    <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/mocha-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/sw-utils.js"></script>
     <script src="/node_modules/mockdate/src/mockdate.js"></script>
     <script src="/node_modules/sinon/pkg/sinon.js"></script>
 

--- a/packages/sw-precaching/build.js
+++ b/packages/sw-precaching/build.js
@@ -12,55 +12,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const rollupBabel = require('rollup-plugin-babel');
-const path = require('path');
-const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
-const {buildJSBundle} = require('../../build-utils');
-const pkg = require('./package.json');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.precaching',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
+
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.precaching');
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-precaching/src/lib/error-factory.js
+++ b/packages/sw-precaching/src/lib/error-factory.js
@@ -18,14 +18,13 @@ import ErrorFactory from '../../../../lib/error-factory';
 const errors = {
   'not-in-sw': 'sw-precaching must be loaded in your service worker file.',
   'invalid-file-manifest-entry': `File manifest entries must be either a ` +
-    `string with revision info in the path or an object with path and ` +
-    `revision and parameters.`,
+    `string with revision info in the url or an object with a 'url' and ` +
+    `'revision' parameters.`,
   'bad-cache-bust': `The cache bust parameter must be a boolean.`,
   'duplicate-entry-diff-revisions': `An attempt was made to cache the same ` +
-    `path twice with each having different revisions. This is not supported.`,
+    `url twice with each having different revisions. This is not supported.`,
   'request-not-cached': `A request failed the criteria to be cached. By ` +
-    `default, only responses with 'response.ok = true' or opaque responses ` +
-    `are cached.`,
+    `default, only responses with 'response.ok = true' are cached.`,
 };
 
 export default new ErrorFactory(errors);

--- a/packages/sw-precaching/src/lib/error-factory.js
+++ b/packages/sw-precaching/src/lib/error-factory.js
@@ -21,6 +21,11 @@ const errors = {
     `string with revision info in the path or an object with path and ` +
     `revision and parameters.`,
   'bad-cache-bust': `The cache bust parameter must be a boolean.`,
+  'duplicate-entry-diff-revisions': `An attempt was made to cache the same ` +
+    `path twice with each having different revisions. This is not supported.`,
+  'request-not-cached': `A request failed the criteria to be cached. By ` +
+    `default, only responses with 'response.ok = true' or opaque responses ` +
+    `are cached.`,
 };
 
 export default new ErrorFactory(errors);

--- a/packages/sw-precaching/src/lib/models/defaults-cache-entry.js
+++ b/packages/sw-precaching/src/lib/models/defaults-cache-entry.js
@@ -2,44 +2,44 @@ import ErrorFactory from '../error-factory';
 import RevisionedCacheEntry from './revisioned-cache-entry.js';
 
 class DefaultsCacheEntry extends RevisionedCacheEntry {
-  constructor({revisionID, revision, request, cacheBust}) {
+  constructor({revisionID, revision, url, cacheBust}) {
     // Check cacheBust is a boolean
     let filteredCacheBust = cacheBust;
     if (typeof filteredCacheBust === 'undefined') {
       filteredCacheBust = true;
     } else if (typeof filteredCacheBust !== 'boolean') {
       throw ErrorFactory.createError('invalid-file-manifest-entry',
-        new Error('Bad CacheBust. It should be a boolean value: ' +
+        new Error('Bad cacheBust Parameter. It should be a boolean value: ' +
           JSON.stringify(cacheBust)));
     }
 
     // Check revision is a string with a length
     if (typeof revision !== 'string' || revision.length === 0) {
       throw ErrorFactory.createError('invalid-file-manifest-entry',
-        new Error('Bad Revision. It should be a string with at least ' +
-          'one character: ' + JSON.stringify(revision)));
+        new Error('Bad revision Parameter. It should be a string with at ' +
+          'least one character: ' + JSON.stringify(revision)));
     }
 
-    // Check request is a string.
-    if (typeof request !== 'string' || request.length === 0) {
+    // Check url is a string.
+    if (typeof url !== 'string' || url.length === 0) {
       throw ErrorFactory.createError('invalid-file-manifest-entry',
-        new Error('Bad Request. It should be a string:' +
-          JSON.stringify(request)));
+        new Error('Bad url Parameter. It should be a string:' +
+          JSON.stringify(url)));
     }
 
     // Check revisionID type
     if (typeof revisionID === 'undefined') {
-      revisionID = request.url;
+      revisionID = new URL(url, location.origin).toString();
     } else if (typeof revisionID !== 'string' || revisionID.length === 0) {
       throw ErrorFactory.createError('invalid-file-manifest-entry',
-        new Error('Bad RevisionID. It should be a string with at least ' +
-          'one character: ' + JSON.stringify(revisionID)));
+        new Error('Bad revisionID Parameter. It should be a string with at ' +
+          'least one character: ' + JSON.stringify(revisionID)));
     }
 
     super({
-      revisionID: new URL(request, location.origin).toString(),
+      revisionID,
       revision,
-      request: new Request(request),
+      request: new Request(url),
       cacheBust,
     });
   }

--- a/packages/sw-precaching/src/lib/models/defaults-cache-entry.js
+++ b/packages/sw-precaching/src/lib/models/defaults-cache-entry.js
@@ -1,0 +1,75 @@
+import ErrorFactory from '../error-factory';
+import RevisionedCacheEntry from './revisioned-cache-entry.js';
+import {cacheBustParamName} from '../constants';
+
+/**
+ * This method takes a file entry and if the `cacheBust` parameter is set to
+ * true, the cacheBust parameter will be added to the URL before making the
+ * request. The response will be cached with the absolute URL without
+ * the cache busting search param.
+ * @param {String} requestURL This is an object with `path`, `revision` and
+ * `cacheBust` parameters.
+ * @param {String} revision Revision to use in the cache bust.
+ * @return {String} The final URL to make the request to then cache.
+ */
+const _cacheBustUrl = (requestURL, revision) => {
+  const parsedURL = new URL(requestURL, location.origin);
+  parsedURL.search += (parsedURL.search ? '&' : '') +
+    encodeURIComponent(cacheBustParamName) + '=' +
+    encodeURIComponent(revision);
+  return parsedURL.toString();
+};
+
+class DefaultsCacheEntry extends RevisionedCacheEntry {
+  constructor({revisionID, revision, request, cacheBust}) {
+    // Check cacheBust type
+    let filteredCacheBust = cacheBust;
+    if (typeof filteredCacheBust === 'undefined') {
+      filteredCacheBust = true;
+    } else if (typeof filteredCacheBust !== 'boolean') {
+      throw ErrorFactory.createError('invalid-file-manifest-entry',
+        new Error('Bad CacheBust. It should be a boolean value: ' +
+          JSON.stringify(cacheBust)));
+    }
+
+    // Check revision type
+    if (typeof revision !== 'string' || revision.length === 0) {
+      throw ErrorFactory.createError('invalid-file-manifest-entry',
+        new Error('Bad Revision. It should be a string with at least ' +
+          'one character: ' + JSON.stringify(revision)));
+    }
+
+    // Check request type
+    if (!(request instanceof Request)) {
+      if (typeof request === 'string') {
+        request = new Request(_cacheBustUrl(request, revision));
+      } else {
+        throw ErrorFactory.createError('invalid-file-manifest-entry',
+          new Error('Bad Request. It should be a string or a Request ' +
+            'object: ' + JSON.stringify(request)));
+      }
+    } else if (cacheBust && cacheBust === true) {
+      throw ErrorFactory.createError('invalid-file-manifest-entry',
+        new Error('Bad Request + CacheBust Combo. Request URLs cannot ' +
+          'have there URLs altered so must be cache busted in your ' +
+          'servicework: ' + JSON.stringify(request)));
+    }
+
+    // Check revisionID type
+    if (typeof revisionID === 'undefined') {
+      revisionID = request.url;
+    } else if (typeof revisionID !== 'string' || revisionID.length === 0) {
+      throw ErrorFactory.createError('invalid-file-manifest-entry',
+        new Error('Bad RevisionID. It should be a string with at least ' +
+          'one character: ' + JSON.stringify(revisionID)));
+    }
+
+    super({
+      revisionID,
+      revision,
+      request,
+    });
+  }
+}
+
+export default DefaultsCacheEntry;

--- a/packages/sw-precaching/src/lib/models/revision-details-model.js
+++ b/packages/sw-precaching/src/lib/models/revision-details-model.js
@@ -1,0 +1,37 @@
+import IDBHelper from '../../../../../lib/idb-helper.js';
+import {dbName, dbVersion, dbStorename} from '../constants';
+
+class RevisionDetailsModel {
+  constructor() {
+    this._idbHelper = new IDBHelper(dbName, dbVersion, dbStorename);
+  }
+
+  /**
+   * This method gets the revision details for a given revisionID.
+   * @param {String} revisionID The ID of the revision.
+   * @return {Promise<String|null>} Returns a string for the last revision or
+   * returns null if there is no revision information.
+   */
+  get(revisionID) {
+    return this._idbHelper.get(revisionID);
+  }
+
+  /**
+   * This method saves the revision details to indexedDB.
+   * @param {String} revisionID The ID of the revision.
+   * @param {String} revision The current revision for this revisionID.
+   * @return {Promise} Promise that resolves once the data has been saved.
+   */
+  put(revisionID, revision) {
+    return this._idbHelper.put(revisionID, revision);
+  }
+
+  /**
+   * This method closes the indexdDB helper.
+   */
+  _close() {
+    this._idbHelper.close();
+  }
+}
+
+export default RevisionDetailsModel;

--- a/packages/sw-precaching/src/lib/models/revisioned-cache-entry.js
+++ b/packages/sw-precaching/src/lib/models/revisioned-cache-entry.js
@@ -1,8 +1,33 @@
+import {cacheBustParamName} from '../constants';
+
 class RevisionedCacheEntry {
-  constructor({revisionID, revision, request}) {
+  constructor({revisionID, revision, request, cacheBust}) {
     this.revisionID = revisionID;
     this.revision = revision;
     this.request = request;
+    this.cacheBust = cacheBust;
+  }
+
+  get cacheBustRequest() {
+    return new Request(this._cacheBustUrl(this.request.url, this.revision));
+  }
+
+  /**
+   * This method takes a file entry and if the `cacheBust` parameter is set to
+   * true, the cacheBust parameter will be added to the URL before making the
+   * request. The response will be cached with the absolute URL without
+   * the cache busting search param.
+   * @param {String} requestURL This is an object with `url`, `revision` and
+   * `cacheBust` parameters.
+   * @param {String} revision Revision to use in the cache bust.
+   * @return {String} The final URL to make the request to then cache.
+   */
+  _cacheBustUrl(requestURL, revision) {
+    const parsedURL = new URL(requestURL, location.origin);
+    parsedURL.search += (parsedURL.search ? '&' : '') +
+      encodeURIComponent(cacheBustParamName) + '=' +
+      encodeURIComponent(revision);
+    return parsedURL.toString();
   }
 }
 

--- a/packages/sw-precaching/src/lib/models/revisioned-cache-entry.js
+++ b/packages/sw-precaching/src/lib/models/revisioned-cache-entry.js
@@ -1,0 +1,9 @@
+class RevisionedCacheEntry {
+  constructor({revisionID, revision, request}) {
+    this.revisionID = revisionID;
+    this.revision = revision;
+    this.request = request;
+  }
+}
+
+export default RevisionedCacheEntry;

--- a/packages/sw-precaching/src/lib/models/revisioned-cache-entry.js
+++ b/packages/sw-precaching/src/lib/models/revisioned-cache-entry.js
@@ -23,6 +23,13 @@ class RevisionedCacheEntry {
    * @return {String} The final URL to make the request to then cache.
    */
   _cacheBustUrl(requestURL, revision) {
+    if ('cache' in Request.prototype) {
+      // Make use of the Request cache mode where we can.
+      // Reload skips the HTTP cache for outgoing requests and updates
+      // the cache with the returned reponse.
+      return new Request(requestURL, {cache: 'reload'});
+    }
+
     const parsedURL = new URL(requestURL, location.origin);
     parsedURL.search += (parsedURL.search ? '&' : '') +
       encodeURIComponent(cacheBustParamName) + '=' +

--- a/packages/sw-precaching/src/lib/models/string-cache-entry.js
+++ b/packages/sw-precaching/src/lib/models/string-cache-entry.js
@@ -1,0 +1,14 @@
+import RevisionedCacheEntry from './revisioned-cache-entry.js';
+
+class StringCacheEntry extends RevisionedCacheEntry {
+  constructor({fileEntry}) {
+    super({
+      revisionID: fileEntry,
+      revision: fileEntry,
+      request: new Request(fileEntry),
+      cacheBust: false,
+    });
+  }
+}
+
+export default StringCacheEntry;

--- a/packages/sw-precaching/src/lib/revisioned-cache-manager.js
+++ b/packages/sw-precaching/src/lib/revisioned-cache-manager.js
@@ -18,8 +18,7 @@ import ErrorFactory from './error-factory';
 import StringCacheEntry from './models/string-cache-entry.js';
 import DefaultsCacheEntry from './models/defaults-cache-entry.js';
 import RevisionDetailsModel from './models/revision-details-model.js';
-import {defaultCacheName}
-  from './constants';
+import {defaultCacheName} from './constants';
 
 /**
  * RevisionedCacheManager manages efficient caching of a file manifest,

--- a/packages/sw-precaching/test/browser-unit/cache-testing.js
+++ b/packages/sw-precaching/test/browser-unit/cache-testing.js
@@ -64,7 +64,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
       const promises = fileSet.map((assetAndHash) => {
         let url = assetAndHash;
         if (typeof assetAndHash === 'object') {
-          url = assetAndHash.path;
+          url = assetAndHash.request;
         }
 
         return iframe.contentWindow.fetch(url);
@@ -93,16 +93,16 @@ describe('sw-precaching Test Revisioned Caching', function() {
   const compareCachedAssets = function(beforeData, afterData) {
     afterData.cacheList.forEach((afterAssetAndHash) => {
       if (typeof assetAndHash === 'string') {
-        afterAssetAndHash = {path: afterAssetAndHash, revision: afterAssetAndHash};
+        afterAssetAndHash = {request: afterAssetAndHash, revision: afterAssetAndHash};
       }
 
       let matchingBeforeAssetAndHash = null;
       beforeData.cacheList.forEach((beforeAssetAndHash) => {
         if (typeof beforeAssetAndHash === 'string') {
-          beforeAssetAndHash = {path: beforeAssetAndHash, revision: beforeAssetAndHash};
+          beforeAssetAndHash = {request: beforeAssetAndHash, revision: beforeAssetAndHash};
         }
 
-        if (beforeAssetAndHash.path === afterAssetAndHash.path) {
+        if (beforeAssetAndHash.request === afterAssetAndHash.request) {
           matchingBeforeAssetAndHash = beforeAssetAndHash;
         }
       });
@@ -111,8 +111,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
         return;
       }
 
-      let pathToCheck = new URL(afterAssetAndHash.path, location.origin).toString();
-
+      let pathToCheck = new URL(afterAssetAndHash.request, location.origin).toString();
       const beforeResponseBody = beforeData.cachedResponses[pathToCheck];
       const afterResponseBody = afterData.cachedResponses[pathToCheck];
 
@@ -132,7 +131,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
       return testFileSet(iframe, goog.__TEST_DATA['set-1']['step-1']);
     })
     .then((step1Responses) => {
-      /** return window.goog.swUtils.activateSW('data/basic-cache/basic-cache-sw-2.js')
+      return window.goog.swUtils.activateSW('data/basic-cache/basic-cache-sw-2.js')
       .then((iframe) => {
         return testFileSet(iframe, goog.__TEST_DATA['set-1']['step-2']);
       })
@@ -144,7 +143,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
           cacheList: goog.__TEST_DATA['set-1']['step-2'],
           cachedResponses: step2Responses,
         });
-      });**/
+      });
     });
   });
 

--- a/packages/sw-precaching/test/browser-unit/cache-testing.js
+++ b/packages/sw-precaching/test/browser-unit/cache-testing.js
@@ -44,7 +44,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
         cachedResponses.forEach((cachedResponse) => {
           let desiredPath = assetAndHash;
           if (typeof assetAndHash !== 'string') {
-            desiredPath = assetAndHash.path;
+            desiredPath = assetAndHash.request;
           }
 
           if (cachedResponse.url.indexOf(desiredPath) !== -1) {
@@ -132,7 +132,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
       return testFileSet(iframe, goog.__TEST_DATA['set-1']['step-1']);
     })
     .then((step1Responses) => {
-      return window.goog.swUtils.activateSW('data/basic-cache/basic-cache-sw-2.js')
+      /** return window.goog.swUtils.activateSW('data/basic-cache/basic-cache-sw-2.js')
       .then((iframe) => {
         return testFileSet(iframe, goog.__TEST_DATA['set-1']['step-2']);
       })
@@ -144,7 +144,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
           cacheList: goog.__TEST_DATA['set-1']['step-2'],
           cachedResponses: step2Responses,
         });
-      });
+      });**/
     });
   });
 
@@ -222,8 +222,10 @@ describe('sw-precaching Test Revisioned Caching', function() {
   it('should cache opaque responses by default', function() {
     return window.goog.swUtils.activateSW('data/response-types/opaque-sw.js')
     .then(() => {
-      // The iframe doesn't allow no-cors requests from the window.
-      return testCacheEntries( goog.__TEST_DATA['opaque']);
+      throw new Error('Expected SW to fail installation due to caching 404 entry.');
+    }, (err) => {
+      // NOOP - The error is not to do with the error throw in SW, so nothing
+      // to check.
     });
   });
 });

--- a/packages/sw-precaching/test/browser-unit/cache-testing.js
+++ b/packages/sw-precaching/test/browser-unit/cache-testing.js
@@ -61,27 +61,24 @@ describe('sw-precaching Test Revisioned Caching', function() {
   const testFileSet = (iframe, fileSet) => {
     return testCacheEntries(fileSet)
     .then(() => {
+      let responses = {};
       const promises = fileSet.map((assetAndHash) => {
         let url = assetAndHash;
         if (typeof assetAndHash === 'object') {
           url = assetAndHash.url;
         }
 
-        return iframe.contentWindow.fetch(url);
-      });
-      return Promise.all(promises);
-    })
-    .then((cachedResponses) => {
-      let responses = {};
-      const promises = cachedResponses.map((cachedResponse) => {
-        if (cachedResponse.type === 'opaque') {
-          responses[cachedResponse.url] = null;
-        } else {
-          return cachedResponse.text()
-          .then((bodyText) => {
-            responses[cachedResponse.url] = bodyText;
-          });
-        }
+        return iframe.contentWindow.fetch(url)
+        .then((cachedResponse) => {
+          if (cachedResponse.type === 'opaque') {
+            responses[url] = null;
+          } else {
+            return cachedResponse.text()
+            .then((bodyText) => {
+              responses[url] = bodyText;
+            });
+          }
+        });
       });
       return Promise.all(promises)
       .then(() => {
@@ -92,7 +89,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
 
   const compareCachedAssets = function(beforeData, afterData) {
     afterData.cacheList.forEach((afterAssetAndHash) => {
-      if (typeof assetAndHash === 'string') {
+      if (typeof afterAssetAndHash === 'string') {
         afterAssetAndHash = {url: afterAssetAndHash, revision: afterAssetAndHash};
       }
 
@@ -111,9 +108,8 @@ describe('sw-precaching Test Revisioned Caching', function() {
         return;
       }
 
-      let pathToCheck = new URL(afterAssetAndHash.url, location.origin).toString();
-      const beforeResponseBody = beforeData.cachedResponses[pathToCheck];
-      const afterResponseBody = afterData.cachedResponses[pathToCheck];
+      const beforeResponseBody = beforeData.cachedResponses[afterAssetAndHash.url];
+      const afterResponseBody = afterData.cachedResponses[afterAssetAndHash.url];
 
       if (matchingBeforeAssetAndHash.revision === afterAssetAndHash.revision) {
         // The request should be the same

--- a/packages/sw-precaching/test/browser-unit/cache-testing.js
+++ b/packages/sw-precaching/test/browser-unit/cache-testing.js
@@ -44,7 +44,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
         cachedResponses.forEach((cachedResponse) => {
           let desiredPath = assetAndHash;
           if (typeof assetAndHash !== 'string') {
-            desiredPath = assetAndHash.request;
+            desiredPath = assetAndHash.url;
           }
 
           if (cachedResponse.url.indexOf(desiredPath) !== -1) {
@@ -64,7 +64,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
       const promises = fileSet.map((assetAndHash) => {
         let url = assetAndHash;
         if (typeof assetAndHash === 'object') {
-          url = assetAndHash.request;
+          url = assetAndHash.url;
         }
 
         return iframe.contentWindow.fetch(url);
@@ -93,16 +93,16 @@ describe('sw-precaching Test Revisioned Caching', function() {
   const compareCachedAssets = function(beforeData, afterData) {
     afterData.cacheList.forEach((afterAssetAndHash) => {
       if (typeof assetAndHash === 'string') {
-        afterAssetAndHash = {request: afterAssetAndHash, revision: afterAssetAndHash};
+        afterAssetAndHash = {url: afterAssetAndHash, revision: afterAssetAndHash};
       }
 
       let matchingBeforeAssetAndHash = null;
       beforeData.cacheList.forEach((beforeAssetAndHash) => {
         if (typeof beforeAssetAndHash === 'string') {
-          beforeAssetAndHash = {request: beforeAssetAndHash, revision: beforeAssetAndHash};
+          beforeAssetAndHash = {url: beforeAssetAndHash, revision: beforeAssetAndHash};
         }
 
-        if (beforeAssetAndHash.request === afterAssetAndHash.request) {
+        if (beforeAssetAndHash.url === afterAssetAndHash.url) {
           matchingBeforeAssetAndHash = beforeAssetAndHash;
         }
       });
@@ -111,7 +111,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
         return;
       }
 
-      let pathToCheck = new URL(afterAssetAndHash.request, location.origin).toString();
+      let pathToCheck = new URL(afterAssetAndHash.url, location.origin).toString();
       const beforeResponseBody = beforeData.cachedResponses[pathToCheck];
       const afterResponseBody = afterData.cachedResponses[pathToCheck];
 

--- a/packages/sw-precaching/test/browser-unit/data/duplicate-entries/duplicate-entries-sw.js
+++ b/packages/sw-precaching/test/browser-unit/data/duplicate-entries/duplicate-entries-sw.js
@@ -1,0 +1,28 @@
+/* global goog, sinon */
+importScripts('/packages/sw-precaching/test/browser-unit/data/test-data.js');
+importScripts('/node_modules/sinon/pkg/sinon.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
+importScripts('/packages/sw-precaching/test/browser-unit/data/skip-and-claim.js');
+
+let requestsMade = [];
+
+sinon.stub(self, 'fetch', (requestUrl) => {
+  requestsMade.push(requestUrl);
+  return Promise.resolve(new Response());
+});
+
+const revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
+goog.__TEST_DATA['duplicate-entries'].forEach((entries) => {
+  revisionedCacheManager.cache({
+    revisionedFiles: entries,
+  });
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url === `${location.origin}/__api/get-requests-made/`) {
+    return event.respondWith(
+      new Response(JSON.stringify(requestsMade))
+    );
+  }
+  event.respondWith(caches.match(event.request));
+});

--- a/packages/sw-precaching/test/browser-unit/data/response-types/404-sw.js
+++ b/packages/sw-precaching/test/browser-unit/data/response-types/404-sw.js
@@ -1,0 +1,9 @@
+/* global goog */
+importScripts('/packages/sw-precaching/test/browser-unit/data/test-data.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
+importScripts('/packages/sw-precaching/test/browser-unit/data/skip-and-claim.js');
+
+const revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
+revisionedCacheManager.cache({
+  revisionedFiles: goog.__TEST_DATA['404'],
+});

--- a/packages/sw-precaching/test/browser-unit/data/response-types/opaque-sw.js
+++ b/packages/sw-precaching/test/browser-unit/data/response-types/opaque-sw.js
@@ -1,0 +1,13 @@
+/* global goog */
+importScripts('/packages/sw-precaching/test/browser-unit/data/test-data.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
+importScripts('/packages/sw-precaching/test/browser-unit/data/skip-and-claim.js');
+
+const revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
+revisionedCacheManager.cache({
+  revisionedFiles: goog.__TEST_DATA['opaque'],
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(caches.match(event.request));
+});

--- a/packages/sw-precaching/test/browser-unit/data/test-data.js
+++ b/packages/sw-precaching/test/browser-unit/data/test-data.js
@@ -24,11 +24,11 @@ const addNewEntry = (origin) => {
     fileIndex++;
 
     EXAMPLE_REVISIONED_FILES_SET_1_STEP_1.push({
-      request: `${origin}${echoPath}/${fileIndex}.txt`,
+      url: `${origin}${echoPath}/${fileIndex}.txt`,
       revision: revision1[i],
     });
     EXAMPLE_REVISIONED_FILES_SET_1_STEP_2.push({
-      request: `${origin}${echoPath}/${fileIndex}.txt`,
+      url: `${origin}${echoPath}/${fileIndex}.txt`,
       revision: revision2[i],
     });
     fileIndex++;

--- a/packages/sw-precaching/test/browser-unit/data/test-data.js
+++ b/packages/sw-precaching/test/browser-unit/data/test-data.js
@@ -24,14 +24,24 @@ const addNewEntry = (origin) => {
     fileIndex++;
 
     EXAMPLE_REVISIONED_FILES_SET_1_STEP_1.push({
-      path: `${origin}${echoPath}/${fileIndex}.txt`,
+      request: `${origin}${echoPath}/${fileIndex}.txt`,
       revision: revision1[i],
     });
     EXAMPLE_REVISIONED_FILES_SET_1_STEP_2.push({
-      path: `${origin}${echoPath}/${fileIndex}.txt`,
+      request: `${origin}${echoPath}/${fileIndex}.txt`,
       revision: revision2[i],
     });
     fileIndex++;
+
+    /** EXAMPLE_REVISIONED_FILES_SET_1_STEP_1.push({
+      path: new Request(`${origin}${echoPath}/${fileIndex}.${revision1[i]}.txt`),
+      revision: revision1[i],
+    });
+    EXAMPLE_REVISIONED_FILES_SET_1_STEP_2.push({
+      path: new Request(`${origin}${echoPath}/${fileIndex}.${revision2[i]}.txt`),
+      revision: revision2[i],
+    });
+    fileIndex++;**/
   }
 };
 

--- a/packages/sw-precaching/test/browser-unit/data/test-data.js
+++ b/packages/sw-precaching/test/browser-unit/data/test-data.js
@@ -50,4 +50,28 @@ self.goog.__TEST_DATA = {
     'step-1': EXAMPLE_REVISIONED_FILES_SET_1_STEP_1,
     'step-2': EXAMPLE_REVISIONED_FILES_SET_1_STEP_2,
   },
+  'duplicate-entries': [
+    [
+      '/__echo/date/1.1234.txt',
+      '/__echo/date/2.1234.txt',
+      '/__echo/date/3.1234.txt',
+      '/__echo/date/4.1234.txt',
+    ],
+    [
+      '/__echo/date/2.1234.txt',
+      '/__echo/date/4.1234.txt',
+      '/__echo/date/5.1234.txt',
+    ],
+    [
+      '/__echo/date/1.1234.txt',
+      '/__echo/date/3.1234.txt',
+      '/__echo/date/6.1234.txt',
+    ],
+  ],
+  '404': [
+    '/__test/404/',
+  ],
+  'opaque': [
+    `${secondaryServer}/__echo/date/hello.txt`,
+  ],
 };

--- a/packages/sw-precaching/test/browser-unit/index.html
+++ b/packages/sw-precaching/test/browser-unit/index.html
@@ -35,8 +35,8 @@
     <script src="/node_modules/mocha/mocha.js"></script>
 
     <!-- sw-testing-helpers -->
-    <script src="/node_modules/sw-testing-helpers/browser/mocha-utils.js"></script>
-    <script src="/node_modules/sw-testing-helpers/browser/sw-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/mocha-utils.js"></script>
+    <script src="/node_modules/sw-testing-helpers/build/browser/sw-utils.js"></script>
     <script src="/node_modules/sinon/pkg/sinon.js"></script>
 
     <!--

--- a/packages/sw-precaching/test/browser-unit/library-namespace.js
+++ b/packages/sw-precaching/test/browser-unit/library-namespace.js
@@ -46,13 +46,7 @@ describe('Test Behaviors of Loading the Script', function() {
   ];
   swUnitTests.forEach((swUnitTestPath) => {
     it(`should perform ${swUnitTestPath} sw tests`, function() {
-      return window.goog.mochaUtils.startServiceWorkerMochaTests(swUnitTestPath)
-      .then((testResults) => {
-        if (testResults.failed.length > 0) {
-          const errorMessage = window.goog.mochaUtils.prettyPrintErrors(swUnitTestPath, testResults);
-          throw new Error(errorMessage);
-        }
-      });
+      return window.goog.mochaUtils.registerServiceWorkerMochaTests(swUnitTestPath);
     });
   });
 });

--- a/packages/sw-precaching/test/browser-unit/sw-unit/basic.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/basic.js
@@ -1,6 +1,6 @@
 importScripts('/node_modules/mocha/mocha.js');
 importScripts('/node_modules/chai/chai.js');
-importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
+importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
 
 importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
 

--- a/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
@@ -1,6 +1,6 @@
 importScripts('/node_modules/mocha/mocha.js');
 importScripts('/node_modules/chai/chai.js');
-importScripts('/node_modules/sw-testing-helpers/browser/mocha-utils.js');
+importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
 
 importScripts('/packages/sw-precaching/build/sw-precaching.min.js');
 

--- a/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
@@ -17,6 +17,10 @@ mocha.setup({
 describe('Test RevisionedCacheManager', function() {
   let revisionedCacheManager;
 
+  const VALID_PATH_REL = '/__echo/date/example.txt';
+  const VALID_PATH_ABS = `${location.origin}${VALID_PATH_REL}`;
+  const VALID_REVISION = '1234';
+
   beforeEach(function() {
     revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
   });
@@ -31,11 +35,13 @@ describe('Test RevisionedCacheManager', function() {
     '',
     '/example.js',
     {},
-    {path: 'hello'},
+    {request: 'hello'},
     {revision: '0987'},
     true,
     false,
     123,
+    new Request(VALID_PATH_ABS),
+    new Request(VALID_PATH_REL),
   ];
   badRevisionFileInputs.forEach((badInput) => {
     it(`should handle bad cache({revisionedFiles='${badInput}'}) input`, function() {
@@ -69,10 +75,6 @@ describe('Test RevisionedCacheManager', function() {
     }).to.throw('null');
   });
 
-  const VALID_PATH_REL = '/__echo/date/example.txt';
-  const VALID_PATH_ABS = `${location.origin}${VALID_PATH_REL}`;
-  const VALID_REVISION = '1234';
-
   const badPaths = [
     null,
     undefined,
@@ -97,10 +99,10 @@ describe('Test RevisionedCacheManager', function() {
   const badFileManifests = [];
   badPaths.forEach((badPath) => {
     badFileManifests.push([badPath]);
-    badFileManifests.push([{path: badPath, revision: VALID_REVISION}]);
+    badFileManifests.push([{request: badPath, revision: VALID_REVISION}]);
   });
   badRevisions.forEach((badRevision) => {
-    badFileManifests.push([{path: VALID_PATH_REL, revision: badRevision}]);
+    badFileManifests.push([{request: VALID_PATH_REL, revision: badRevision}]);
   });
 
   badFileManifests.forEach((badFileManifest) => {
@@ -115,7 +117,6 @@ describe('Test RevisionedCacheManager', function() {
       if (!caughtError) {
         throw new Error('Expected file manifest to cause an error.');
       }
-
       caughtError.name.should.equal('invalid-file-manifest-entry');
     });
   });
@@ -134,7 +135,7 @@ describe('Test RevisionedCacheManager', function() {
       let caughtError;
       try {
         revisionedCacheManager.cache({revisionedFiles: [
-          {path: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: badCacheBust},
+          {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: badCacheBust},
         ]});
       } catch (err) {
         caughtError = err;
@@ -150,13 +151,19 @@ describe('Test RevisionedCacheManager', function() {
 
   const goodManifestInputs = [
     VALID_PATH_REL,
-    {path: VALID_PATH_REL, revision: VALID_REVISION},
-    {path: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: true},
-    {path: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: false},
+    {request: VALID_PATH_REL, revision: VALID_REVISION},
+    {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: true},
+    {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: false},
+    {request: new Request(VALID_PATH_REL), revision: VALID_REVISION},
+    {request: new Request(VALID_PATH_REL), revision: VALID_REVISION, cacheBust: true},
+    {request: new Request(VALID_PATH_REL), revision: VALID_REVISION, cacheBust: false},
     VALID_PATH_ABS,
-    {path: VALID_PATH_ABS, revision: VALID_REVISION},
-    {path: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: true},
-    {path: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: false},
+    {request: VALID_PATH_ABS, revision: VALID_REVISION},
+    {request: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: true},
+    {request: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: false},
+    {request: new Request(VALID_PATH_ABS), revision: VALID_REVISION},
+    {request: new Request(VALID_PATH_ABS), revision: VALID_REVISION, cacheBust: true},
+    {request: new Request(VALID_PATH_ABS), revision: VALID_REVISION, cacheBust: false},
   ];
   goodManifestInputs.forEach((goodInput) => {
     it(`should be able to handle good cache input '${JSON.stringify(goodInput)}'`, function() {
@@ -169,10 +176,10 @@ describe('Test RevisionedCacheManager', function() {
     let thrownError = null;
     try {
       revisionedCacheManager.cache({revisionedFiles: [
-        {path: TEST_PATH, revision: '1234'},
+        {request: TEST_PATH, revision: '1234'},
       ]});
       revisionedCacheManager.cache({revisionedFiles: [
-        {path: TEST_PATH, revision: '5678'},
+        {request: TEST_PATH, revision: '5678'},
       ]});
     } catch (err) {
       thrownError = err;

--- a/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
@@ -154,16 +154,10 @@ describe('Test RevisionedCacheManager', function() {
     {request: VALID_PATH_REL, revision: VALID_REVISION},
     {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: true},
     {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: false},
-    {request: new Request(VALID_PATH_REL), revision: VALID_REVISION},
-    {request: new Request(VALID_PATH_REL), revision: VALID_REVISION, cacheBust: true},
-    {request: new Request(VALID_PATH_REL), revision: VALID_REVISION, cacheBust: false},
     VALID_PATH_ABS,
     {request: VALID_PATH_ABS, revision: VALID_REVISION},
     {request: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: true},
     {request: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: false},
-    {request: new Request(VALID_PATH_ABS), revision: VALID_REVISION},
-    {request: new Request(VALID_PATH_ABS), revision: VALID_REVISION, cacheBust: true},
-    {request: new Request(VALID_PATH_ABS), revision: VALID_REVISION, cacheBust: false},
   ];
   goodManifestInputs.forEach((goodInput) => {
     it(`should be able to handle good cache input '${JSON.stringify(goodInput)}'`, function() {

--- a/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
@@ -35,7 +35,7 @@ describe('Test RevisionedCacheManager', function() {
     '',
     '/example.js',
     {},
-    {request: 'hello'},
+    {url: 'hello'},
     {revision: '0987'},
     true,
     false,
@@ -99,10 +99,10 @@ describe('Test RevisionedCacheManager', function() {
   const badFileManifests = [];
   badPaths.forEach((badPath) => {
     badFileManifests.push([badPath]);
-    badFileManifests.push([{request: badPath, revision: VALID_REVISION}]);
+    badFileManifests.push([{url: badPath, revision: VALID_REVISION}]);
   });
   badRevisions.forEach((badRevision) => {
-    badFileManifests.push([{request: VALID_PATH_REL, revision: badRevision}]);
+    badFileManifests.push([{url: VALID_PATH_REL, revision: badRevision}]);
   });
 
   badFileManifests.forEach((badFileManifest) => {
@@ -135,7 +135,7 @@ describe('Test RevisionedCacheManager', function() {
       let caughtError;
       try {
         revisionedCacheManager.cache({revisionedFiles: [
-          {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: badCacheBust},
+          {url: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: badCacheBust},
         ]});
       } catch (err) {
         caughtError = err;
@@ -151,13 +151,13 @@ describe('Test RevisionedCacheManager', function() {
 
   const goodManifestInputs = [
     VALID_PATH_REL,
-    {request: VALID_PATH_REL, revision: VALID_REVISION},
-    {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: true},
-    {request: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: false},
+    {url: VALID_PATH_REL, revision: VALID_REVISION},
+    {url: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: true},
+    {url: VALID_PATH_REL, revision: VALID_REVISION, cacheBust: false},
     VALID_PATH_ABS,
-    {request: VALID_PATH_ABS, revision: VALID_REVISION},
-    {request: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: true},
-    {request: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: false},
+    {url: VALID_PATH_ABS, revision: VALID_REVISION},
+    {url: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: true},
+    {url: VALID_PATH_ABS, revision: VALID_REVISION, cacheBust: false},
   ];
   goodManifestInputs.forEach((goodInput) => {
     it(`should be able to handle good cache input '${JSON.stringify(goodInput)}'`, function() {
@@ -170,10 +170,10 @@ describe('Test RevisionedCacheManager', function() {
     let thrownError = null;
     try {
       revisionedCacheManager.cache({revisionedFiles: [
-        {request: TEST_PATH, revision: '1234'},
+        {url: TEST_PATH, revision: '1234'},
       ]});
       revisionedCacheManager.cache({revisionedFiles: [
-        {request: TEST_PATH, revision: '5678'},
+        {url: TEST_PATH, revision: '5678'},
       ]});
     } catch (err) {
       thrownError = err;

--- a/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
+++ b/packages/sw-precaching/test/browser-unit/sw-unit/revisioned-cache-manager.js
@@ -17,12 +17,13 @@ mocha.setup({
 describe('Test RevisionedCacheManager', function() {
   let revisionedCacheManager;
 
-  before(function() {
+  beforeEach(function() {
     revisionedCacheManager = new goog.precaching.RevisionedCacheManager();
   });
 
-  after(function() {
+  afterEach(function() {
     revisionedCacheManager._close();
+    revisionedCacheManager = null;
   });
 
   const badRevisionFileInputs = [
@@ -161,5 +162,22 @@ describe('Test RevisionedCacheManager', function() {
     it(`should be able to handle good cache input '${JSON.stringify(goodInput)}'`, function() {
       revisionedCacheManager.cache({revisionedFiles: [goodInput]});
     });
+  });
+
+  it('should throw error when precaching the same path but different revision', function() {
+    const TEST_PATH = '/__echo/date/hello.txt';
+    let thrownError = null;
+    try {
+      revisionedCacheManager.cache({revisionedFiles: [
+        {path: TEST_PATH, revision: '1234'},
+      ]});
+      revisionedCacheManager.cache({revisionedFiles: [
+        {path: TEST_PATH, revision: '5678'},
+      ]});
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    thrownError.name.should.equal('duplicate-entry-diff-revisions');
   });
 });

--- a/packages/sw-routing/build.js
+++ b/packages/sw-routing/build.js
@@ -13,40 +13,12 @@
  limitations under the License.
 */
 
-const commonjs = require('rollup-plugin-commonjs');
-const nodeResolve = require('rollup-plugin-node-resolve');
-const path = require('path');
 const pkg = require('./package.json');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-const pluginsConfig = [
-  nodeResolve({
-    jsnext: true,
-    main: true,
-  }),
-  commonjs(),
-];
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.routing');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        plugins: pluginsConfig,
-        format: 'umd',
-        moduleName: 'goog.routing',
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        plugins: pluginsConfig,
-        format: 'es',
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-runtime-caching/build.js
+++ b/packages/sw-runtime-caching/build.js
@@ -13,41 +13,12 @@
  limitations under the License.
 */
 
-const rollupBabel = require('rollup-plugin-babel');
-const path = require('path');
-const {buildJSBundle} = require('../../build-utils');
 const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.runtimeCaching',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main,
+}, __dirname, 'goog.runtimeCaching');
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/templates/README.hbs
+++ b/templates/README.hbs
@@ -8,6 +8,9 @@
 ## The Libraries
 {{#each projects}}
 ### {{name}}
+
+[![Build Status](https://travis-shields.appspot.com/shield/GoogleChrome/sw-helpers/master/PROJECT%3D%22{{name}}%22)][travis-url]
+
 {{description}}
 
 **Install**: `npm install --save-dev {{name}}`

--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -47,6 +47,10 @@ class ServerInstance {
   }
 
   start(rootDirectory, port) {
+    if (typeof port === 'undefined') {
+      port = 0;
+    }
+
     if (this._server) {
       return Promise.reject(new Error('Server already started.'));
     }
@@ -62,6 +66,13 @@ class ServerInstance {
 
     return new Promise((resolve, reject) => {
       this._server = this._app.listen(port, 'localhost', () => {
+        if (process.env.TRAVIS) {
+          /* eslint-disable no-console */
+          console.log(`[Debug Info] Test Server: ` +
+            `http://localhost:${this._server.address().port}`);
+          console.log('');
+          /* eslint-enable no-console */
+        }
         resolve(this._server.address().port);
       });
     });

--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -39,10 +39,16 @@ class ServerInstance {
       res.send(`${req.params.file}-${Date.now()}`);
     });
 
-    this._app.get('/__echo/date-with-cors/:file', function(req, res) {
+    this._app.all('/__echo/date-with-cors/:file', function(req, res) {
+      res.setHeader('Access-Control-Allow-Methods',
+        'POST, GET, PUT, DELETE, OPTIONS');
       res.setHeader('Cache-Control', 'max-age=' + (24 * 60 * 60));
       res.setHeader('Access-Control-Allow-Origin', '*');
       res.send(`${req.params.file}-${Date.now()}`);
+    });
+
+    this._app.get('/__test/404/', function(req, res) {
+      res.status(404).send('404');
     });
   }
 

--- a/utils/test-server.js
+++ b/utils/test-server.js
@@ -38,7 +38,7 @@ module.exports = {
     }
 
     if (!port) {
-      port = 0;
+      port = 3004;
     }
 
     primaryServer = new ServerInstance();


### PR DESCRIPTION
R: @jeffposnick @addyosmani

This is a slight change on the previous precaching PR (previous comments have been taken into account here).

- This has tests for caching relative, absolute, CORs and Local requests. The entries in the file manifest are now parsed by a CacheEntry model (this handles defaults and checking the input is valid).

- Rejigged some of the code so that the RevisionedCacheManager is a little leaner and the code is easier to read.

- Changed {path: '', revision: ''} -> {url: '', revision: ''}
