### PR TITLE
Refactor the build process; build minified + non-minified libraries

### DIFF
--- a/build-utils.js
+++ b/build-utils.js
@@ -20,6 +20,7 @@ const path = require('path');
 const promisify = require('promisify-node');
 const fs = require('fs');
 const gulp = require('gulp');
+const gulpif = require('gulp-if');
 const sourcemaps = require('gulp-sourcemaps');
 const rename = require('gulp-rename');
 const rollup = require('gulp-rollup');
@@ -27,6 +28,8 @@ const babel = require('gulp-babel');
 const header = require('gulp-header');
 
 const globPromise = promisify('glob');
+
+const LICENSE_HEADER = fs.readFileSync('LICENSE-HEADER', 'utf8');
 
 /**
  * Wrapper on top of childProcess.spawn() that returns a promise which rejects
@@ -94,41 +97,85 @@ function taskHarness(task, projectOrStar, ...args) {
  * also add a license header and create sourcemaps.
  *
  * @param  {Object} options Options object with 'projectDir' and 'rollupConfig'
- * @return {[type]}         [description]
+ * @return {Promise}
  */
 function buildJSBundle(options) {
-  const destPath = path.join(options.projectDir, 'build');
-  const licenseHeader = fs.readFileSync('LICENSE-HEADER', 'utf8');
-
-  if (options.outputName.indexOf('build/') !== 0) {
-    throw new Error('Expected options.ouputName to start with \'build/\'');
-  }
-
   return new Promise((resolve, reject) => {
-    gulp.src([
-      path.join(options.projectDir, 'src', '**', '*.js'),
-      path.join('lib', '**', '*.js'),
-      path.join('packages', '**', '*.js'),
-      path.join('node_modules', '*', '**', '*.js'),
-    ])
-    .pipe(sourcemaps.init())
-    .pipe(rollup(options.rollupConfig))
-    .pipe(babel({
-      presets: ['babili', {comments: false}],
-    }))
-    .pipe(header(licenseHeader))
-    .pipe(rename(options.outputName.substring('build/'.length)))
-    // Source maps are written relative tot he gulp.dest() path
-    .pipe(sourcemaps.write('.'))
-    .pipe(gulp.dest(destPath))
-    .on('error', (err) => {
-      reject(err);
-    })
-    .on('end', () => {
-      resolve();
-    });
+    const outputName = options.buildPath.replace(/^build\//, '');
+    const sources = [
+      `${options.projectDir}/src/**/*.js`,
+      '{lib,packages}/**/*.js',
+      'node_modules/*/**/*.js'
+    ];
+
+    gulp.src(sources)
+      .pipe(sourcemaps.init())
+      .pipe(rollup(options.rollupConfig))
+      .pipe(gulpif(options.minify, babel({
+        presets: ['babili', {comments: false}],
+      })))
+      .pipe(header(LICENSE_HEADER))
+      .pipe(rename(outputName))
+      .pipe(sourcemaps.write('.'))
+      .pipe(gulp.dest(`${options.projectDir}/build`))
+      .on('error', reject)
+      .on('end', resolve);
   });
 }
 
-module.exports = {globPromise, processPromiseWrapper,
-  taskHarness, buildJSBundle};
+/**
+ * A helper to generate Rollup build configurations.
+ *
+ * One build config is generated for each format given in formatToPath.
+ * Both minified and unminified build configs are generated.
+ *
+ * @param {Object.<String,String>} formatToPath A mapping of each format
+ *        ('umd', 'es', etc.) to the path to use for the output.
+ * @param {String} projectDir The path of the project directory.
+ * @param {String} moduleName The name of the module, used in the UMD output.
+ * @param {Array.<Object>} [plugins] A list of Rollup plugins to use.
+ * @returns {Array.<Object>}
+ */
+function generateBuildConfigs(formatToPath, projectDir, moduleName, plugins) {
+  // This is shared throughout the full permutation of build configs.
+  const baseConfig = {
+    rollupConfig: {
+      entry: path.join(projectDir, 'src', 'index.js'),
+      plugins,
+      moduleName,
+    },
+    projectDir,
+  };
+
+  // Use Object.assign() throughout to create copies of the config objects.
+  return [true, false].map((minify) => {
+    return Object.assign({}, baseConfig, {minify});
+  }).map((partialConfig) => {
+    return Object.keys(formatToPath).map((format) => {
+      const fullConfig = Object.assign({}, partialConfig, {
+        buildPath: formatToPath[format],
+      });
+      fullConfig.rollupConfig = Object.assign({}, partialConfig.rollupConfig, {
+        format,
+      });
+
+      // Remove the '.min.' from the file name if the output isn't minified.
+      if (!fullConfig.minify) {
+        fullConfig.buildPath = fullConfig.buildPath.replace('.min.', '.');
+      }
+
+      return fullConfig;
+    });
+  }).reduce((previous, current) => {
+    // Flatten the two-dimensional array.
+    return previous.concat(current);
+  }, []);
+}
+
+module.exports = {
+  buildJSBundle,
+  generateBuildConfigs,
+  globPromise,
+  processPromiseWrapper,
+  taskHarness
+};

--- a/build-utils.js
+++ b/build-utils.js
@@ -105,7 +105,7 @@ function buildJSBundle(options) {
     const sources = [
       `${options.projectDir}/src/**/*.js`,
       '{lib,packages}/**/*.js',
-      'node_modules/*/**/*.js'
+      'node_modules/*/**/*.js',
     ];
 
     gulp.src(sources)
@@ -177,5 +177,5 @@ module.exports = {
   generateBuildConfigs,
   globPromise,
   processPromiseWrapper,
-  taskHarness
+  taskHarness,
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-eslint": "^3.0.1",
     "gulp-header": "^1.8.8",
+    "gulp-if": "^2.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-rollup": "^2.5.1",
     "gulp-spawn-mocha": "^3.1.0",

--- a/packages/sw-appcache-behavior/build.js
+++ b/packages/sw-appcache-behavior/build.js
@@ -32,7 +32,7 @@ module.exports = () => {
           commonjs(),
         ],
       },
-      outputName: 'build/client-runtime.js',
+      buildPath: 'build/client-runtime.js',
       projectDir: __dirname,
     }),
     buildJSBundle({
@@ -49,7 +49,7 @@ module.exports = () => {
           commonjs(),
         ],
       },
-      outputName: 'build/appcache-behavior-import.js',
+      buildPath: 'build/appcache-behavior-import.js',
       projectDir: __dirname,
     }),
   ]);

--- a/packages/sw-appcache-behavior/build.js
+++ b/packages/sw-appcache-behavior/build.js
@@ -12,6 +12,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');

--- a/packages/sw-background-sync-queue/build.js
+++ b/packages/sw-background-sync-queue/build.js
@@ -35,7 +35,7 @@ const plugins = [
 
 const mainModuleBuilds = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.backgroundSyncQueue', plugins).map(buildJSBundle);
 
 module.exports = () => Promise.all([

--- a/packages/sw-background-sync-queue/build.js
+++ b/packages/sw-background-sync-queue/build.js
@@ -20,23 +20,10 @@ const resolve = require('rollup-plugin-node-resolve');
 const rollupBabel = require('rollup-plugin-babel');
 const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-const plugins = [
-  resolve({
-    jsnext: true,
-    main: true,
-    browser: true,
-  }),
-  rollupBabel({
-    plugins: ['transform-async-to-generator', 'external-helpers'],
-    exclude: 'node_modules/**',
-  }),
-  commonjs(),
-];
-
 const mainModuleBuilds = generateBuildConfigs({
   es: pkg['jsnext:main'],
   umd: pkg.main,
-}, __dirname, 'goog.backgroundSyncQueue', plugins).map(buildJSBundle);
+}, __dirname, 'goog.backgroundSyncQueue').map(buildJSBundle);
 
 module.exports = () => Promise.all([
   ...mainModuleBuilds,

--- a/packages/sw-background-sync-queue/build.js
+++ b/packages/sw-background-sync-queue/build.js
@@ -15,95 +15,95 @@
 
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');
+const pkg = require('./package.json');
 const resolve = require('rollup-plugin-node-resolve');
 const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/background-sync-queue.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'request-queue.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue.test.RequestQueue',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/request-queue.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'background-sync-queue.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue.test.BackgroundSyncQueue',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/background-sync-queue.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
-        format: 'umd',
-        moduleName: 'goog.backgroundSyncQueue.test.constants',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/constants.js',
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const plugins = [
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  rollupBabel({
+    plugins: ['transform-async-to-generator', 'external-helpers'],
+    exclude: 'node_modules/**',
+  }),
+  commonjs(),
+];
+
+const mainModuleBuilds = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.backgroundSyncQueue', plugins).map(buildJSBundle);
+
+module.exports = () => Promise.all([
+  ...mainModuleBuilds,
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'request-queue.js'),
+      format: 'umd',
+      moduleName: 'goog.backgroundSyncQueue.test.RequestQueue',
+      plugins: [
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        rollupBabel({
+          plugins: ['transform-async-to-generator', 'external-helpers'],
+          exclude: 'node_modules/**',
+        }),
+        commonjs(),
+      ],
+    },
+    buildPath: 'build/test/request-queue.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'background-sync-queue.js'),
+      format: 'umd',
+      moduleName: 'goog.backgroundSyncQueue.test.BackgroundSyncQueue',
+      plugins: [
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        rollupBabel({
+          plugins: ['transform-async-to-generator', 'external-helpers'],
+          exclude: 'node_modules/**',
+        }),
+        commonjs(),
+      ],
+    },
+    buildPath: 'build/test/background-sync-queue.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
+      format: 'umd',
+      moduleName: 'goog.backgroundSyncQueue.test.constants',
+      plugins: [
+        resolve({
+          jsnext: true,
+          main: true,
+          browser: true,
+        }),
+        rollupBabel({
+          plugins: ['transform-async-to-generator', 'external-helpers'],
+          exclude: 'node_modules/**',
+        }),
+        commonjs(),
+      ],
+    },
+    buildPath: 'build/test/constants.js',
+    projectDir: __dirname,
+  }),
+]);

--- a/packages/sw-background-sync-queue/package.json
+++ b/packages/sw-background-sync-queue/package.json
@@ -14,7 +14,7 @@
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",
   "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-background-sync-queue",
-  "main": "build/background-sync-queue.js",
+  "main": "build/background-sync-queue.min.js",
   "module": "build/background-sync-queue.min.mjs",
   "jsnext:main": "build/background-sync-queue.min.mjs"
 }

--- a/packages/sw-broadcast-cache-update/build.js
+++ b/packages/sw-broadcast-cache-update/build.js
@@ -18,7 +18,7 @@ const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.broadcastCacheUpdate');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-broadcast-cache-update/build.js
+++ b/packages/sw-broadcast-cache-update/build.js
@@ -12,28 +12,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const path = require('path');
-const {buildJSBundle} = require('../../build-utils');
-const pkg = require('./package.json');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.broadcastCacheUpdate',
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
+
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.broadcastCacheUpdate');
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cache-expiration/build.js
+++ b/packages/sw-cache-expiration/build.js
@@ -13,28 +13,12 @@
  limitations under the License.
 */
 
-const commonjs = require('rollup-plugin-commonjs');
 const pkg = require('./package.json');
-const resolve = require('rollup-plugin-node-resolve');
-const rollupBabel = require('rollup-plugin-babel');
 const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
-
-const plugins = [
-  rollupBabel({
-    plugins: ['transform-async-to-generator', 'external-helpers'],
-    exclude: 'node_modules/**',
-  }),
-  resolve({
-    jsnext: true,
-    main: true,
-    browser: true,
-  }),
-  commonjs(),
-];
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
   umd: pkg.main,
-}, __dirname, 'goog.cacheExpiration', plugins);
+}, __dirname, 'goog.cacheExpiration');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cache-expiration/build.js
+++ b/packages/sw-cache-expiration/build.js
@@ -14,54 +14,27 @@
 */
 
 const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
 const pkg = require('./package.json');
 const resolve = require('rollup-plugin-node-resolve');
 const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.cacheExpiration',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const plugins = [
+  rollupBabel({
+    plugins: ['transform-async-to-generator', 'external-helpers'],
+    exclude: 'node_modules/**',
+  }),
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  commonjs(),
+];
+
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.cacheExpiration', plugins);
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cache-expiration/build.js
+++ b/packages/sw-cache-expiration/build.js
@@ -34,7 +34,7 @@ const plugins = [
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.cacheExpiration', plugins);
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cli/build.js
+++ b/packages/sw-cli/build.js
@@ -12,28 +12,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
-const pkg = require('./package.json');
-const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-const plugins = [
-  rollupBabel({
-    plugins: ['transform-async-to-generator', 'external-helpers'],
-    exclude: 'node_modules/**',
-  }),
-  resolve({
-    jsnext: true,
-    main: true,
-    browser: true,
-  }),
-  commonjs(),
-];
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
   umd: pkg.main,
-}, __dirname, 'goog.swcli', plugins);
+}, __dirname, 'goog.swcli');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cli/build.js
+++ b/packages/sw-cli/build.js
@@ -14,54 +14,26 @@
 */
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
 const pkg = require('./package.json');
 const rollupBabel = require('rollup-plugin-babel');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
+const plugins = [
+  rollupBabel({
+    plugins: ['transform-async-to-generator', 'external-helpers'],
+    exclude: 'node_modules/**',
+  }),
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  commonjs(),
+];
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.swcli',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.swcli', plugins);
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cli/build.js
+++ b/packages/sw-cli/build.js
@@ -33,7 +33,7 @@ const plugins = [
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.swcli', plugins);
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-lib/build.js
+++ b/packages/sw-lib/build.js
@@ -12,35 +12,29 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const rollupBabel = require('rollup-plugin-babel');
-const resolve = require('rollup-plugin-node-resolve');
+
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');
-const packageJson = require('./package.json');
-const {buildJSBundle} = require('../../build-utils');
+const pkg = require('./package.json');
+const resolve = require('rollup-plugin-node-resolve');
+const rollupBabel = require('rollup-plugin-babel');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.swlib',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: packageJson.main,
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const plugins = [
+  rollupBabel({
+    plugins: ['transform-async-to-generator', 'external-helpers'],
+    exclude: 'node_modules/**',
+  }),
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  commonjs(),
+];
+
+const buildConfigs = generateBuildConfigs({
+  umd: pkg.main
+}, __dirname, 'goog.swlib', plugins);
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-lib/build.js
+++ b/packages/sw-lib/build.js
@@ -14,7 +14,6 @@
 */
 
 const commonjs = require('rollup-plugin-commonjs');
-const path = require('path');
 const pkg = require('./package.json');
 const resolve = require('rollup-plugin-node-resolve');
 const rollupBabel = require('rollup-plugin-babel');
@@ -34,7 +33,7 @@ const plugins = [
 ];
 
 const buildConfigs = generateBuildConfigs({
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.swlib', plugins);
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-lib/build.js
+++ b/packages/sw-lib/build.js
@@ -13,27 +13,11 @@
  limitations under the License.
 */
 
-const commonjs = require('rollup-plugin-commonjs');
 const pkg = require('./package.json');
-const resolve = require('rollup-plugin-node-resolve');
-const rollupBabel = require('rollup-plugin-babel');
 const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
-
-const plugins = [
-  rollupBabel({
-    plugins: ['transform-async-to-generator', 'external-helpers'],
-    exclude: 'node_modules/**',
-  }),
-  resolve({
-    jsnext: true,
-    main: true,
-    browser: true,
-  }),
-  commonjs(),
-];
 
 const buildConfigs = generateBuildConfigs({
   umd: pkg.main,
-}, __dirname, 'goog.swlib', plugins);
+}, __dirname, 'goog.swlib');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-offline-google-analytics/build.js
+++ b/packages/sw-offline-google-analytics/build.js
@@ -30,7 +30,7 @@ const plugins = [
 
 const mainModuleBuilds = generateBuildConfigs({
   umd: pkg.main,
-}, __dirname, 'goog.offlineGoogleAnalytics', plugins).map(buildJSBundle);
+}, __dirname, 'goog.offlineGoogleAnalytics').map(buildJSBundle);
 
 module.exports = () => Promise.all([
   ...mainModuleBuilds,

--- a/packages/sw-offline-google-analytics/build.js
+++ b/packages/sw-offline-google-analytics/build.js
@@ -29,7 +29,7 @@ const plugins = [
 ];
 
 const mainModuleBuilds = generateBuildConfigs({
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.offlineGoogleAnalytics', plugins).map(buildJSBundle);
 
 module.exports = () => Promise.all([

--- a/packages/sw-offline-google-analytics/build.js
+++ b/packages/sw-offline-google-analytics/build.js
@@ -12,97 +12,70 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
 const path = require('path');
-const {buildJSBundle} = require('../../build-utils');
+const pkg = require('./package.json');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/offline-google-analytics-import.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'enqueue-request.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.enqueueRequest',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/enqueue-request.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'replay-queued-requests.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.replayRequests',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/replay-queued-requests.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.constants',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/constants.js',
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, '..', '..', 'lib', 'idb-helper.js'),
-        format: 'umd',
-        moduleName: 'goog.offlineGoogleAnalytics.test.IDBHelper',
-        plugins: [
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: 'build/test/idb-helper.js',
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const plugins = [
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  commonjs(),
+];
+
+const mainModuleBuilds = generateBuildConfigs({
+  umd: pkg.main
+}, __dirname, 'goog.offlineGoogleAnalytics', plugins).map(buildJSBundle);
+
+module.exports = () => Promise.all([
+  ...mainModuleBuilds,
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'enqueue-request.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.enqueueRequest',
+      plugins,
+    },
+    buildPath: 'build/test/enqueue-request.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'replay-queued-requests.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.replayRequests',
+      plugins,
+    },
+    buildPath: 'build/test/replay-queued-requests.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, 'src', 'lib', 'constants.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.constants',
+      plugins,
+    },
+    buildPath: 'build/test/constants.js',
+    projectDir: __dirname,
+  }),
+
+  buildJSBundle({
+    rollupConfig: {
+      entry: path.join(__dirname, '..', '..', 'lib', 'idb-helper.js'),
+      format: 'umd',
+      moduleName: 'goog.offlineGoogleAnalytics.test.IDBHelper',
+      plugins,
+    },
+    buildPath: 'build/test/idb-helper.js',
+    projectDir: __dirname,
+  }),
+]);

--- a/packages/sw-offline-google-analytics/package.json
+++ b/packages/sw-offline-google-analytics/package.json
@@ -16,5 +16,6 @@
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",
-  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics"
+  "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics",
+  "main": "build/offline-google-analytics-import.min.js"
 }

--- a/packages/sw-precaching/build.js
+++ b/packages/sw-precaching/build.js
@@ -12,55 +12,29 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-const rollupBabel = require('rollup-plugin-babel');
-const path = require('path');
-const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
-const {buildJSBundle} = require('../../build-utils');
-const pkg = require('./package.json');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.precaching',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-          resolve({
-            jsnext: true,
-            main: true,
-            browser: true,
-          }),
-          commonjs(),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const commonjs = require('rollup-plugin-commonjs');
+const pkg = require('./package.json');
+const resolve = require('rollup-plugin-node-resolve');
+const rollupBabel = require('rollup-plugin-babel');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
+
+const plugins = [
+  rollupBabel({
+    plugins: ['transform-async-to-generator', 'external-helpers'],
+    exclude: 'node_modules/**',
+  }),
+  resolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+  commonjs(),
+];
+
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.precaching', plugins);
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-precaching/build.js
+++ b/packages/sw-precaching/build.js
@@ -13,28 +13,12 @@
  limitations under the License.
 */
 
-const commonjs = require('rollup-plugin-commonjs');
 const pkg = require('./package.json');
-const resolve = require('rollup-plugin-node-resolve');
-const rollupBabel = require('rollup-plugin-babel');
 const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
-
-const plugins = [
-  rollupBabel({
-    plugins: ['transform-async-to-generator', 'external-helpers'],
-    exclude: 'node_modules/**',
-  }),
-  resolve({
-    jsnext: true,
-    main: true,
-    browser: true,
-  }),
-  commonjs(),
-];
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
   umd: pkg.main,
-}, __dirname, 'goog.precaching', plugins);
+}, __dirname, 'goog.precaching');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-precaching/build.js
+++ b/packages/sw-precaching/build.js
@@ -34,7 +34,7 @@ const plugins = [
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.precaching', plugins);
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-routing/build.js
+++ b/packages/sw-routing/build.js
@@ -15,11 +15,10 @@
 
 const commonjs = require('rollup-plugin-commonjs');
 const nodeResolve = require('rollup-plugin-node-resolve');
-const path = require('path');
 const pkg = require('./package.json');
-const {buildJSBundle} = require('../../build-utils');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-const pluginsConfig = [
+const plugins = [
   nodeResolve({
     jsnext: true,
     main: true,
@@ -27,26 +26,9 @@ const pluginsConfig = [
   commonjs(),
 ];
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        plugins: pluginsConfig,
-        format: 'umd',
-        moduleName: 'goog.routing',
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        plugins: pluginsConfig,
-        format: 'es',
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.routing', plugins);
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-routing/build.js
+++ b/packages/sw-routing/build.js
@@ -28,7 +28,7 @@ const plugins = [
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.routing', plugins);
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-routing/build.js
+++ b/packages/sw-routing/build.js
@@ -13,22 +13,12 @@
  limitations under the License.
 */
 
-const commonjs = require('rollup-plugin-commonjs');
-const nodeResolve = require('rollup-plugin-node-resolve');
 const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
-
-const plugins = [
-  nodeResolve({
-    jsnext: true,
-    main: true,
-  }),
-  commonjs(),
-];
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
   umd: pkg.main,
-}, __dirname, 'goog.routing', plugins);
+}, __dirname, 'goog.routing');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-runtime-caching/build.js
+++ b/packages/sw-runtime-caching/build.js
@@ -14,17 +14,11 @@
 */
 
 const pkg = require('./package.json');
-const rollupBabel = require('rollup-plugin-babel');
 const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
-
-const plugins = [rollupBabel({
-  plugins: ['transform-async-to-generator', 'external-helpers'],
-  exclude: 'node_modules/**',
-})];
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
   umd: pkg.main,
-}, __dirname, 'goog.runtimeCaching', plugins);
+}, __dirname, 'goog.runtimeCaching');
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-runtime-caching/build.js
+++ b/packages/sw-runtime-caching/build.js
@@ -13,41 +13,18 @@
  limitations under the License.
 */
 
-const rollupBabel = require('rollup-plugin-babel');
-const path = require('path');
-const {buildJSBundle} = require('../../build-utils');
 const pkg = require('./package.json');
+const rollupBabel = require('rollup-plugin-babel');
+const {buildJSBundle, generateBuildConfigs} = require('../../build-utils');
 
-module.exports = () => {
-  return Promise.all([
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'umd',
-        moduleName: 'goog.runtimeCaching',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-        ],
-      },
-      outputName: pkg.main,
-      projectDir: __dirname,
-    }),
-    buildJSBundle({
-      rollupConfig: {
-        entry: path.join(__dirname, 'src', 'index.js'),
-        format: 'es',
-        plugins: [
-          rollupBabel({
-            plugins: ['transform-async-to-generator', 'external-helpers'],
-            exclude: 'node_modules/**',
-          }),
-        ],
-      },
-      outputName: pkg['jsnext:main'],
-      projectDir: __dirname,
-    }),
-  ]);
-};
+const plugins = [rollupBabel({
+  plugins: ['transform-async-to-generator', 'external-helpers'],
+  exclude: 'node_modules/**',
+})];
+
+const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
+  umd: pkg.main
+}, __dirname, 'goog.runtimeCaching', plugins);
+
+module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-runtime-caching/build.js
+++ b/packages/sw-runtime-caching/build.js
@@ -24,7 +24,7 @@ const plugins = [rollupBabel({
 
 const buildConfigs = generateBuildConfigs({
   es: pkg['jsnext:main'],
-  umd: pkg.main
+  umd: pkg.main,
 }, __dirname, 'goog.runtimeCaching', plugins);
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));


### PR DESCRIPTION
R: @addyosmani @gauntface
CC: @deanhume

This PR refactors much of the common build boilerplate into a helper method. That helper method also takes care of generating both minified and non-minified output, which fixes #31.

There are some packages that still require slightly different build setups, either due to their testing requirements or due to their legacy packaging requirements. In those cases I've switched over the part of the build that could be abstracted out into the general configuration, and left behind the things that needed to stay separate.