### PR TITLE
Adding tests for file extension selection

### DIFF
--- a/packages/sw-cli/src/cli/index.js
+++ b/packages/sw-cli/src/cli/index.js
@@ -26,6 +26,8 @@ const logHelper = require('../lib/log-helper');
 const pkg = require('../../package.json');
 const constants = require('../lib/constants.js');
 
+const DEBUG = false;
+
 /**
  * This class is a wrapper to make test easier. This is used by
  * ./bin/index.js to pass in the args when the CLI is used.
@@ -126,17 +128,12 @@ class SWCli {
   generateSW() {
     return this._getRootOfWebApp()
     .then((rootDirectory) => {
+      return this._getFileExtensionsToCache(rootDirectory);
+    })
+    .then((fileExtensionsToCache) => {
 
     });
     /** return inquirer.prompt([
-      {
-        name: 'rootDir',
-        message: 'What is the root of your web app?',
-        validate: () => {
-          // TODO: Validate user input
-          return true;
-        },
-      },
       {
         name: 'fileExtensions',
         message: 'Which file types would you like to cache?',
@@ -228,6 +225,91 @@ class SWCli {
       );
       throw err;
     });
+  }
+
+  _getFileExtensionsToCache(rootDirectory) {
+    return this._getFileContents(rootDirectory)
+    .then((files) => {
+      return this._getFileExtensions(files);
+    })
+    .then((fileExtensions) => {
+      if (fileExtensions.length === 0) {
+        throw new Error(errors['no-file-extensions-found']);
+      }
+
+      return inquirer.prompt([
+        {
+          name: 'cacheExtensions',
+          message: 'Which file types would you like to cache?',
+          type: 'checkbox',
+          choices: fileExtensions,
+          default: fileExtensions,
+        },
+      ]);
+    })
+    .then((results) => {
+      if (results.cacheExtensions.length === 0) {
+        throw new Error(errors['no-file-extensions-selected']);
+      }
+
+      return results.cacheExtensions;
+    })
+    .catch((err) => {
+      logHelper.error(
+        errors['unable-to-get-file-extensions'],
+        err
+      );
+      throw err;
+    });
+  }
+
+  _getFileContents(directory) {
+    return new Promise((resolve, reject) => {
+      fs.readdir(directory, (err, directoryContents) => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve(directoryContents);
+      });
+    })
+    .then((directoryContents) => {
+      const promises = directoryContents.map((directoryContent) => {
+        const fullPath = path.join(directory, directoryContent);
+        if (fs.statSync(fullPath).isDirectory()) {
+          if (!constants.blacklistDirectoryNames.includes(directoryContent)) {
+            return this._getFileContents(fullPath);
+          } else {
+            return [];
+          }
+        } else {
+          return Promise.resolve(fullPath);
+        }
+      });
+
+      return Promise.all(promises);
+    })
+    .then((fileResults) => {
+      return fileResults.reduce((collapsedFiles, fileResult) => {
+        return collapsedFiles.concat(fileResult);
+      }, []);
+    });
+  }
+
+  _getFileExtensions(files) {
+    const fileExtensions = {};
+    files.forEach((file) => {
+      const extension = path.extname(file);
+      if (extension && extension.length > 0) {
+        fileExtensions[extension] = true;
+      } else if (DEBUG) {
+        logHelper.warn(
+          errors['no-extension'],
+          file
+        );
+      }
+    });
+    return Object.keys(fileExtensions);
   }
 
   /**

--- a/packages/sw-cli/src/cli/index.js
+++ b/packages/sw-cli/src/cli/index.js
@@ -283,7 +283,7 @@ class SWCli {
             return [];
           }
         } else {
-          return Promise.resolve(fullPath);
+          return fullPath;
         }
       });
 

--- a/packages/sw-cli/src/cli/index.js
+++ b/packages/sw-cli/src/cli/index.js
@@ -297,11 +297,11 @@ class SWCli {
   }
 
   _getFileExtensions(files) {
-    const fileExtensions = {};
+    const fileExtensions = new Set();
     files.forEach((file) => {
       const extension = path.extname(file);
       if (extension && extension.length > 0) {
-        fileExtensions[extension] = true;
+        fileExtensions.add(extension);
       } else if (DEBUG) {
         logHelper.warn(
           errors['no-extension'],
@@ -309,7 +309,7 @@ class SWCli {
         );
       }
     });
-    return Object.keys(fileExtensions);
+    return [...fileExtensions];
   }
 
   /**

--- a/packages/sw-cli/src/lib/errors.js
+++ b/packages/sw-cli/src/lib/errors.js
@@ -1,3 +1,11 @@
 module.exports = {
   'unable-to-get-rootdir': 'Unable to get the root directory of your web app.',
+  'unable-to-get-file-extensions': 'Unable to get file extensions to ' +
+    'determine files to cache.',
+  'no-extension': 'Unable to detect a usable extension for a file in your ' +
+    'web app directory.',
+  'no-file-extensions-found': 'No files could be found that are suitable for ' +
+    'caching.',
+  'no-file-extensions-selected': 'No file extensions were selected so nothing '+
+    'would be cached.',
 };

--- a/packages/sw-cli/src/lib/log-helper.js
+++ b/packages/sw-cli/src/lib/log-helper.js
@@ -29,8 +29,12 @@ class LogHelper {
    * Print a warning message to the console (Colored yellow).
    * @param {string} msg Message to print to the console
    */
-  warn(msg) {
-    console.warn(chalk.yellow(msg));
+  warn(msg, runtimeInfo) {
+    let loggedMsg = chalk.yellow(msg);
+    if (runtimeInfo) {
+      loggedMsg += ` ${runtimeInfo}`;
+    }
+    console.warn(loggedMsg);
   }
 
   /**

--- a/packages/sw-cli/test/cli-file-extensions.js
+++ b/packages/sw-cli/test/cli-file-extensions.js
@@ -1,0 +1,296 @@
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const path = require('path');
+const cliHelper = require('./helpers/cli-test-helper.js');
+const errors = require('../src/lib/errors.js');
+
+require('chai').should();
+
+describe('Ask for File Extensions to Cache', function() {
+  const globalStubs = [];
+
+  afterEach(function() {
+    cliHelper.endLogCapture();
+    globalStubs.forEach((stub) => {
+      stub.restore();
+    });
+  });
+
+  const INJECTED_ERROR = new Error('Injected Error');
+  const INITIAL_ROOT_DIR = '/';
+  const VALID_DIRECTORY_CONTENTS = [
+    'injected-file-1.txt',
+    'injected-dir-1',
+  ];
+
+  const checkError = (cli, expectedErrorCode, checkInjectedError) => {
+    return cli._getFileExtensionsToCache(INITIAL_ROOT_DIR)
+    .then(() => {
+      throw new Error('Expected error to be thrown.');
+    }, (err) => {
+      if (typeof checkInjectedError === 'undefined' ||
+        checkInjectedError === true) {
+        err.should.equal(INJECTED_ERROR);
+      }
+    })
+    .then(() => {
+      const captured = cliHelper.endLogCapture();
+      captured.consoleLogs.length.should.equal(0);
+      captured.consoleWarns.length.should.equal(0);
+      captured.consoleErrors.length.should.not.equal(0);
+
+      let foundErrorMsg = false;
+      let foundInjectedErrorMsg = false;
+      captured.consoleErrors.forEach((errLog) => {
+        if (errLog.indexOf(errors[expectedErrorCode]) !== -1) {
+          foundErrorMsg = true;
+        }
+        if (errLog.indexOf(INJECTED_ERROR.message) !== -1) {
+          foundInjectedErrorMsg = true;
+        }
+      });
+      foundErrorMsg.should.equal(true);
+      if (typeof checkInjectedError === 'undefined' ||
+        checkInjectedError === true) {
+        foundInjectedErrorMsg.should.equal(true);
+      }
+    });
+  };
+
+  it('should handle an error from \'fs.readdir()\' on first call', function() {
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        cb(INJECTED_ERROR);
+      },
+    };
+
+    const SWCli = proxyquire('../src/cli/index', {
+      fs: fakeFS,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return checkError(cli, 'unable-to-get-file-extensions');
+  });
+
+  it('should handle an error from \'fs.readdir()\' during scan', function() {
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        if (directory === INITIAL_ROOT_DIR) {
+          cb(null, VALID_DIRECTORY_CONTENTS);
+        } else {
+          cb(INJECTED_ERROR);
+        }
+      },
+      statSync: (directory) => {
+        if (directory === '/injected-file-1.txt') {
+          return {
+            isDirectory: () => {
+              return false;
+            },
+          };
+        } else {
+          return {
+            isDirectory: () => {
+              return true;
+            },
+          };
+        }
+      },
+    };
+
+    const SWCli = proxyquire('../src/cli/index', {
+      fs: fakeFS,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return checkError(cli, 'unable-to-get-file-extensions');
+  });
+
+  it('should handle an error from \'fs.statSync()\'', function() {
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        if (directory === INITIAL_ROOT_DIR) {
+          cb(null, VALID_DIRECTORY_CONTENTS);
+        } else {
+          cb(null, []);
+        }
+      },
+      statSync: (name) => {
+        throw INJECTED_ERROR;
+      },
+    };
+
+    const SWCli = proxyquire('../src/cli/index', {
+      fs: fakeFS,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return checkError(cli, 'unable-to-get-file-extensions');
+  });
+
+  it('should handle no file extensions being available', function() {
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        if (directory === INITIAL_ROOT_DIR) {
+          cb(null, [
+            'LICENSE',
+            'README',
+          ]);
+        }
+      },
+      statSync: (directory) => {
+        return {
+          isDirectory: () => {
+            return false;
+          },
+        };
+      },
+    };
+
+    const SWCli = proxyquire('../src/cli/index', {
+      'fs': fakeFS,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return checkError(cli, 'no-file-extensions-found', false);
+  });
+
+  it('should handle an error from \'inquirer\'', function() {
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        if (directory === INITIAL_ROOT_DIR) {
+          cb(null, VALID_DIRECTORY_CONTENTS);
+        } else {
+          cb(null, []);
+        }
+      },
+      statSync: (directory) => {
+        if (directory === '/injected-file-1.txt') {
+          return {
+            isDirectory: () => {
+              return false;
+            },
+          };
+        } else {
+          return {
+            isDirectory: () => {
+              return true;
+            },
+          };
+        }
+      },
+    };
+
+    const inquirer = require('inquirer');
+    const stub = sinon.stub(inquirer, 'prompt', () => {
+      return Promise.reject(INJECTED_ERROR);
+    });
+
+    globalStubs.push(stub);
+
+    const SWCli = proxyquire('../src/cli/index', {
+      'fs': fakeFS,
+      'inquirer': inquirer,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return checkError(cli, 'unable-to-get-file-extensions');
+  });
+
+  it('should hanlde no files extensions from \'inquirer\'', function() {
+    const FILE_ONLY_INPUT = [
+      'hello.txt',
+      'hello.md',
+      'hello.js',
+    ];
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        cb(null, FILE_ONLY_INPUT);
+      },
+      statSync: (name) => {
+        return {
+          isDirectory: () => {
+            return false;
+          },
+        };
+      },
+    };
+
+    const inquirer = require('inquirer');
+    const stub = sinon.stub(inquirer, 'prompt', (questions) => {
+      const results = {};
+      results[questions[0].name] = [];
+      return Promise.resolve(results);
+    });
+
+    globalStubs.push(stub);
+
+    const SWCli = proxyquire('../src/cli/index', {
+      'fs': fakeFS,
+      'inquirer': inquirer,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return checkError(cli, 'no-file-extensions-selected', false);
+  });
+
+  it('should return files extensions from \'inquirer\'', function() {
+    const FILE_ONLY_INPUT = [
+      'hello.txt',
+      'hello.md',
+      'hello.js',
+    ];
+    const fakeFS = {
+      readdir: (directory, cb) => {
+        cb(null, FILE_ONLY_INPUT);
+      },
+      statSync: (name) => {
+        return {
+          isDirectory: () => {
+            return false;
+          },
+        };
+      },
+    };
+
+    const inquirer = require('inquirer');
+    const stub = sinon.stub(inquirer, 'prompt', (questions) => {
+      questions.length.should.be.gt(0);
+      const choices = questions[0].choices;
+      choices.length.should.equal(FILE_ONLY_INPUT.length);
+      FILE_ONLY_INPUT.forEach((fileName, index) => {
+        choices[index].should.equal(path.extname(fileName));
+      });
+
+      const results = {};
+      results[questions[0].name] = [path.extname(FILE_ONLY_INPUT[0])];
+      return Promise.resolve(results);
+    });
+
+    globalStubs.push(stub);
+
+    const SWCli = proxyquire('../src/cli/index', {
+      'fs': fakeFS,
+      'inquirer': inquirer,
+    });
+
+    cliHelper.startLogCapture();
+    const cli = new SWCli();
+    return cli._getFileExtensionsToCache(INITIAL_ROOT_DIR)
+    .then((fileExtensions) => {
+      const captured = cliHelper.endLogCapture();
+      captured.consoleLogs.length.should.equal(0);
+      captured.consoleWarns.length.should.equal(0);
+      captured.consoleErrors.length.should.equal(0);
+
+      fileExtensions.length.should.equal(1);
+      fileExtensions[0].should.equal(path.extname(FILE_ONLY_INPUT[0]));
+    });
+  });
+});


### PR DESCRIPTION
R: @jeffposnick @addyosmani

Fixes #82

This adds in the ability to select file extensions that the developer would wish to cache under the current directory.

This may need changed if developers aren't a fan of it, but I think it matches precache in terms of just working (everything is selected by default) but adds a nice level of flexibility to cut out unexpected files.

![](http://i.imgur.com/s7eQtp2.png)