### PR TITLE
Explicitly set `redirect: follow` when precaching

### DIFF
--- a/packages/sw-precaching/src/lib/revisioned-cache-manager.js
+++ b/packages/sw-precaching/src/lib/revisioned-cache-manager.js
@@ -256,6 +256,7 @@ class RevisionedCacheManager {
 
     let response = await fetch(fileEntry.cacheBustRequest, {
         credentials: 'same-origin',
+        redirect: 'follow',
       });
 
     if (response.ok) {


### PR DESCRIPTION
R: @addyosmani @gauntface

See https://github.com/GoogleChrome/sw-precache/pull/233

The same thing should apply here.