### PR TITLE
Adds a waitOnCache parameter to fetchAndCache()

### DIFF
--- a/packages/sw-runtime-caching/demo/service-worker.js
+++ b/packages/sw-runtime-caching/demo/service-worker.js
@@ -2,9 +2,9 @@
 /* global goog */
 
 importScripts(
-  '../build/routing.min.js',
-  '../../sw-runtime-caching/build/runtime-caching.min.js',
-  '../../sw-broadcast-cache-update/build/broadcast-cache-update.min.js'
+  '../../sw-routing/build/sw-routing.min.js',
+  '../../sw-runtime-caching/build/sw-runtime-caching.min.js',
+  '../../sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
 );
 
 // Have the service worker take control as soon as possible.

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -191,7 +191,7 @@ class RequestWrapper {
     }
 
     // Only conditionally await the caching completion, giving developers the
-    // option if returning early for, e.g., read-through-caching scenarios.
+    // option of returning early for, e.g., read-through-caching scenarios.
     if (waitOnCache && cachingComplete) {
       await cachingComplete;
     }

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -145,12 +145,16 @@ class RequestWrapper {
    * lifecycle callback.
    *
    * @param {Object} input
-   * @param {Request} input.request
+   * @param {Request} input.request The request to fetch.
+   * @param {boolean} [input.waitOnCache] `true` means the method should wait
+   *        for the cache.put() to complete before returning. The default value
+   *        of `false` means return without waiting.
    * @return {Promise.<Response>} The network response.
    */
-  async fetchAndCache({request}) {
+  async fetchAndCache({request, waitOnCache}) {
     assert.atLeastOne({request});
 
+    let cachingComplete;
     const response = await this.fetch({request});
 
     // .ok is true if the response status is 2xx. That's the default condition.
@@ -163,9 +167,9 @@ class RequestWrapper {
     if (cacheable) {
       const newResponse = response.clone();
 
-      // Run the cache update sequence asynchronously, without blocking the
-      // response from getting to the client.
-      this.getCache().then(async (cache) => {
+      // cacheDelay is a promise that may or may not be used to delay the
+      // completion of this method, depending on the value of `waitOnCache`.
+      cachingComplete = this.getCache().then(async (cache) => {
         let oldResponse;
 
         // Only bother getting the old response if the new response isn't opaque
@@ -186,8 +190,12 @@ class RequestWrapper {
       });
     }
 
-    // Return a response right away, so that the client could make use of it,
-    // without waiting for the cache update sequence to complete.
+    // Only conditionally await the caching completion, giving developers the
+    // option if returning early for, e.g., read-through-caching scenarios.
+    if (waitOnCache && cachingComplete) {
+      await cachingComplete;
+    }
+
     return response;
   }
 }


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #99

This adds a new `waitOnCache` option that can be passed to `RequestWrapper#fetchAndCache()`. I *think* that's enough to allow @gauntface to start using `RequestWrapper` inside the precaching code, which would be a nice thing to do to ensure that all fetches/caching goes through a common code path.

If there's anything else that's needed to make `RequestWrapper` usable, @gauntface, let me know and I'll adjust this PR.

This also fixes up some paths in the demo code, which is unfortunately how I'm testing the changes. (Real tests are forthcoming!)