### PR TITLE
Use the master, instead of the future-of-sw-tooling, branch

### DIFF
--- a/templates/Project-README.hbs
+++ b/templates/Project-README.hbs
@@ -7,7 +7,7 @@
 
 ## Demo
 
-Browse sample source code in the [demo directory](https://github.com/GoogleChrome/sw-helpers/tree/future-of-sw-tooling/packages/{{name}}/demo), or
+Browse sample source code in the [demo directory](https://github.com/GoogleChrome/sw-helpers/tree/master/packages/{{name}}/demo), or
 [try it out](https://googlechrome.github.io/sw-helpers/{{name}}/demo/) directly.
 
 ## API


### PR DESCRIPTION
R: @addyosmani @gauntface

Tiny fix to the URLs we point to from the generated docs.