### PR TITLE
Clean up the parameters that are passed to the handler

### DIFF
--- a/packages/sw-lib/test/browser-unit/sw-unit/router.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/router.js
@@ -49,7 +49,7 @@ describe('Test swlib.router', function() {
     },
   ];
   badInput.forEach((badInput) => {
-    it(`should throw on adding invalid route: '${badInput}'`, function() {
+    it(`should throw on adding invalid route: ${JSON.stringify(badInput)}`, function() {
       let thrownError = null;
       try {
         goog.swlib.router.registerRoute(badInput.capture, () => {});
@@ -75,9 +75,9 @@ describe('Test swlib.router', function() {
       goog.swlib.router.registerRoute(expressRoute, (args) => {
         (args.event instanceof FetchEvent).should.equal(true);
         args.url.toString().should.equal(new URL(exampleRoute, location).toString());
-        args.params[0].should.equal(exampleRoute);
-        args.params[1].should.equal(date.toString());
-        args.params[2].should.equal(fakeID);
+        Object.keys(args.params).length.should.equal(2);
+        args.params.date.should.equal(date.toString());
+        args.params.id.should.equal(fakeID);
 
         resolve();
       });
@@ -98,8 +98,8 @@ describe('Test swlib.router', function() {
       goog.swlib.router.registerRoute(regexRoute, (args) => {
         (args.event instanceof FetchEvent).should.equal(true);
         args.url.toString().should.equal(new URL(exampleRoute, location).toString());
-        args.params[0].should.equal(exampleRoute);
-        args.params[1].should.equal(capturingGroup);
+        args.params.length.should.equal(1);
+        args.params[0].should.equal(capturingGroup);
 
         resolve();
       });

--- a/packages/sw-routing/demo/service-worker.js
+++ b/packages/sw-routing/demo/service-worker.js
@@ -16,8 +16,8 @@ const route = new goog.routing.ExpressRoute({
     handle: ({event, params}) => {
       console.log('The matching params are', params);
       return fetch(event.request);
-    }
-  }
+    },
+  },
 });
 
 const router = new goog.routing.Router();

--- a/packages/sw-routing/demo/service-worker.js
+++ b/packages/sw-routing/demo/service-worker.js
@@ -2,27 +2,23 @@
 /* global goog */
 
 importScripts(
-  '../build/routing.min.js',
-  '../../sw-runtime-caching/build/runtime-caching.min.js',
-  '../../sw-broadcast-cache-update/build/broadcast-cache-update.min.js'
+  '../../sw-routing/build/sw-routing.min.js',
+  '../../sw-runtime-caching/build/sw-runtime-caching.min.js'
 );
 
 // Have the service worker take control as soon as possible.
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', () => self.clients.claim());
 
-const requestWrapper = new goog.runtimeCaching.RequestWrapper({
-  cacheName: 'text-files',
-  behaviors: [
-    new goog.broadcastCacheUpdate.Behavior({channelName: 'cache-updates'}),
-  ],
-});
-
-const route = new goog.routing.RegExpRoute({
-  regExp: /\.txt$/,
-  handler: new goog.runtimeCaching.StaleWhileRevalidate({requestWrapper}),
+const route = new goog.routing.ExpressRoute({
+  path: '/packages/:project/demo/:file',
+  handler: {
+    handle: ({event, params}) => {
+      console.log('The matching params are', params);
+      return fetch(event.request);
+    }
+  }
 });
 
 const router = new goog.routing.Router();
 router.registerRoute({route});
-router.setDefaultHandler({handler: new goog.runtimeCaching.NetworkFirst()});

--- a/packages/sw-routing/src/lib/regexp-route.js
+++ b/packages/sw-routing/src/lib/regexp-route.js
@@ -25,14 +25,32 @@ import assert from '../../../../lib/assert';
  */
 class RegExpRoute extends Route {
   /**
-   * @param {RegExp} regExp The regular expression to match against URL's.
+   * @param {RegExp} regExp The regular expression to match against URLs.
+   *        If the `RegExp` contains [capture groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#grouping-back-references),
+   *        then the array of captured values will be passed to the handler via
+   *        `params`.
    * @param {function} handler The handler to manage the response.
+   * @param {string} [method] Only match requests that use this
+   *        HTTP method. Defaults to `'GET'` if not specified.
    */
   constructor({regExp, handler, method}) {
     assert.isInstance({regExp}, RegExp);
     assert.hasMethod({handler}, 'handle');
 
-    const match = ({url}) => url.href.match(regExp);
+    const match = ({url}) => {
+      const regexpMatches = url.href.match(regExp);
+      // Return null immediately if this route doesn't match.
+      if (!regexpMatches) {
+        return null;
+      }
+
+      // If the route matches, but there aren't any capture groups defined, then
+      // this will return [], which is truthy and therefore sufficient to
+      // indicate a match.
+      // If there are capture groups, then it will return their values.
+      return regexpMatches.slice(1);
+    };
+
     super({match, handler, method});
   }
 }

--- a/packages/sw-routing/src/lib/route.js
+++ b/packages/sw-routing/src/lib/route.js
@@ -17,26 +17,19 @@ import assert from '../../../../lib/assert';
 import {defaultMethod, validMethods} from './constants';
 
 /**
- * The Route class is used to configure a *when*
- * [predicate](https://en.wikipedia.org/wiki/Predicate_(mathematical_logic))
- * a handler.
- *
- * The *when* predicate is used by the Router to determine if a given request
- * matches this Route. If *when* returns true (i.e. this route matches the
- * current request), then the handler will be given the
- * [FetchEvent](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent)
- * so that it can respond to the request.
- *
  * @memberof module:sw-routing
  */
 class Route {
   /**
-   * The constructor for Route expects an object with `when` and `handler`
+   * The constructor for Route expects an object with `match` and `handler`
    * properties which should both be functions.
-   * @param {Object} options - Options to initialize the Route with.
-   * @param {function} options.when - The when predicate function.
-   * @param {function} options.handler - The handler function that will respond
-   * to a FetchEvent.
+   *
+   * @param {function} match - The function that determines whether the
+   *        route matches.
+   * @param {Object} handler - An Object with a `handle` method. That method
+   *        will be used to respond to matching requests.
+   * @param {string} [method] Only match requests that use this
+   *        HTTP method. Defaults to `'GET'` if not specified.
    */
   constructor({match, handler, method} = {}) {
     assert.isType({match}, 'function');

--- a/packages/sw-routing/src/lib/router.js
+++ b/packages/sw-routing/src/lib/router.js
@@ -71,12 +71,19 @@ class Router {
         }
 
         const matchResult = route.match({url, event});
-        if (matchResult || matchResult === 0 || matchResult === '') {
-          responsePromise = route.handler.handle({
-            url,
-            event,
-            params: matchResult,
-          });
+        if (matchResult) {
+          let params = matchResult;
+
+          if (Array.isArray(params) && params.length === 0) {
+            // Instead of passing an empty array in as params, use undefined.
+            params = undefined;
+          } else if (params.constructor === Object &&
+                     Object.keys(params).length === 0) {
+            // Instead of passing an empty object in as params, use undefined.
+            params = undefined;
+          }
+
+          responsePromise = route.handler.handle({url, event, params});
           break;
         }
       }


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #107 

This leads to less cruft being passed along to the handler's `params` when using the `RegExpRoute` or `ExpressRoute` classes along with capture groups/named parameters.

I've got some tests for this module in flight at https://github.com/GoogleChrome/sw-helpers/tree/sw-routing-tests and I'll add tests for this modified functionality as part of a PR for that branch.