### PR TITLE
Remove cacheName from sw-lib cachingStrategy.

### DIFF
--- a/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
@@ -69,7 +69,6 @@ describe('Test caching strategies.', function() {
       // between the request wrapper and the cache expiration behavior.
       const CACHE_NAME = 'hello-world-' + Date.now();
       const CACHE_EXPIRATION = {
-        cacheName: CACHE_NAME,
         maxEntries: 10,
         maxAgeSeconds: 60 * 60,
       };

--- a/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
@@ -65,7 +65,6 @@ describe('Test caching strategies.', function() {
     });
 
     it(`should return a Handler when '${strategy}' is instantiated with cacheExpiration options`, function() {
-      const CACHE_NAME = 'hello-world-' + Date.now();
       const CACHE_EXPIRATION = {
         maxEntries: 10,
         maxAgeSeconds: 60 * 60,

--- a/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
@@ -65,8 +65,6 @@ describe('Test caching strategies.', function() {
     });
 
     it(`should return a Handler when '${strategy}' is instantiated with cacheExpiration options`, function() {
-      // TODO: Is the cache name needed long term? This introduces a difference
-      // between the request wrapper and the cache expiration behavior.
       const CACHE_NAME = 'hello-world-' + Date.now();
       const CACHE_EXPIRATION = {
         maxEntries: 10,


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Fixes #122

Just removes a now unnecessary cacheName parameter.