### PR TITLE
Remove manifest

### DIFF
--- a/gulp-tasks/lint.js
+++ b/gulp-tasks/lint.js
@@ -24,7 +24,10 @@ const {taskHarness} = require('../build-utils');
  */
 const lintPackage = (projectPath) => {
   return new Promise((resolve, reject) => {
-    gulp.src([`${projectPath}/**/*.js`, `!${projectPath}/**/build/**`])
+    gulp.src([`${projectPath}/**/*.js`,
+      `!${projectPath}/**/build/**`,
+      `!${projectPath}/**/node_modules/**`,
+      ])
       .pipe(eslint())
       .pipe(eslint.format())
       .pipe(eslint.results((results) => {

--- a/packages/sw-cli/src/cli/index.js
+++ b/packages/sw-cli/src/cli/index.js
@@ -172,10 +172,16 @@ class SWCli {
           `.{${fileExtentionsToCache.join(',')}}`,
       ];
 
+      const excludeFiles = [
+        fileManifestName,
+        relativePath, serviceWorkerName,
+      ];
+
       return this._buildFileManifestFromGlobs(
         path.join(rootDirectory, fileManifestName),
         rootDirectory,
-        globs
+        globs,
+        excludeFiles
       );
     });
   }
@@ -409,14 +415,15 @@ class SWCli {
     });
   }
 
-  _buildFileManifestFromGlobs(manifestFilePath, rootDirectory, globs) {
+  _buildFileManifestFromGlobs(manifestFilePath, rootDirectory,
+      globs, excludeFiles) {
     const globbedFiles = globs.reduce((accumulated, globPattern) => {
       const fileDetails = this._getFileManifestDetails(
         rootDirectory, globPattern);
       return accumulated.concat(fileDetails);
     }, []);
 
-    const manifestEntries = this._filterFiles(globbedFiles);
+    const manifestEntries = this._filterFiles(globbedFiles, excludeFiles);
 
     return this._writeFilemanifest(manifestFilePath, manifestEntries);
   }
@@ -464,30 +471,29 @@ class SWCli {
     });
   }
 
-  _filterFiles(files) {
-    // Filter oversize files.
+  _filterFiles(files, excludeFiles) {
     files = files.filter((fileDetails) => {
+      // Filter oversize files.
       if (fileDetails.size > constants.maximumFileSize) {
         logHelper.warn(`Skipping file '${fileDetails.file}' due to size. ` +
           `[Max size supported is ${constants.maximumFileSize}]`);
         return false;
       }
 
+      // Filter out excluded files (i.e. manifest and service worker)
+      if (excludeFiles.indexOf(fileDetails.file) !== -1) {
+        return false;
+      }
+
       return true;
     });
 
-    // TODO Filter manifest file itself
-
-    // TODO Filter service worker file itself
-
     // TODO: Strip prefix
-
-    // TODO: Swap path.sep with '/'
 
     // Convert to manifest format
     return files.map((fileDetails) => {
       return {
-        url: fileDetails.file,
+        url: '/' + fileDetails.file.replace(path.sep, '/'),
         revision: fileDetails.hash,
       };
     });
@@ -510,7 +516,7 @@ class SWCli {
 
       const fileHash = this._getFileHash(file);
       return {
-        file: `/${path.relative(rootDirectory, file)}`,
+        file: `${path.relative(rootDirectory, file)}`,
         hash: fileHash,
         size: fileSize,
       };

--- a/packages/sw-cli/test/build-file-manifest.js
+++ b/packages/sw-cli/test/build-file-manifest.js
@@ -218,7 +218,7 @@ describe('Build File Manifest', function() {
       files.forEach((fileDetails) => {
         fileDetails.size.should.equal(INJECTED_SIZE);
         fileDetails.hash.should.equal(INJECTED_HASH);
-        if ([`/${OK_FILE_1}`, `/${OK_FILE_2}`].indexOf(fileDetails.file) === -1) {
+        if ([OK_FILE_1, OK_FILE_2].indexOf(fileDetails.file) === -1) {
           throw new Error('Unexpected Filename: ' + fileDetails.file);
         }
       });
@@ -229,19 +229,19 @@ describe('Build File Manifest', function() {
     it('should filter out files above maximum size', function() {
       const goodFiles = [
         {
-          file: '/ok.txt',
+          file: 'ok.txt',
           size: 1234,
           hash: 'example-hash',
         },
         {
-          file: '/ok-2.txt',
+          file: 'ok-2.txt',
           size: constants.maximumFileSize,
           hash: 'example-hash-2',
         },
       ];
 
       const badFile = {
-        file: '/not-ok.txt',
+        file: 'not-ok.txt',
         size: constants.maximumFileSize + 1,
         hash: 'example-hash',
       };
@@ -251,7 +251,7 @@ describe('Build File Manifest', function() {
       const SWCli = proxyquire('../src/cli/index', {});
       const cli = new SWCli();
       cliHelper.startLogCapture();
-      const manifestEntries = cli._filterFiles(allFiles);
+      const manifestEntries = cli._filterFiles(allFiles, []);
 
       const captured = cliHelper.endLogCapture();
       captured.consoleLogs.length.should.equal(0);
@@ -263,7 +263,7 @@ describe('Build File Manifest', function() {
       manifestEntries.forEach((manifestEntry) => {
         let matchingGoodFile = null;
         goodFiles.forEach((goodFile) => {
-          if (goodFile.file === manifestEntry.url) {
+          if (`/${goodFile.file}` === manifestEntry.url) {
             matchingGoodFile = goodFile;
           }
         });
@@ -272,23 +272,23 @@ describe('Build File Manifest', function() {
           throw new Error('Unable to find matching file for manifest entry: ');
         }
 
-        manifestEntry.url.should.equal(matchingGoodFile.file);
+        manifestEntry.url.should.equal(`/${matchingGoodFile.file}`);
         manifestEntry.revision.should.equal(matchingGoodFile.hash);
       });
     });
 
     it('should filter manifest and service worker', function() {
-      const SW_FILE = '/example/sw.js';
-      const MANIFEST_FILE = '/example/manifest.js';
+      const SW_FILE = 'sw.js';
+      const MANIFEST_FILE = 'manifest.js';
 
       const goodFiles = [
         {
-          file: '/ok.txt',
+          file: 'ok.txt',
           size: 1234,
           hash: 'example-hash',
         },
         {
-          file: '/ok-2.txt',
+          file: 'ok-2.txt',
           size: constants.maximumFileSize,
           hash: 'example-hash-2',
         },
@@ -309,11 +309,14 @@ describe('Build File Manifest', function() {
       const SWCli = proxyquire('../src/cli/index', {});
       const cli = new SWCli();
       // cliHelper.startLogCapture();
-      const manifestEntries = cli._filterFiles(allFiles);
+      const manifestEntries = cli._filterFiles(allFiles, [
+        SW_FILE,
+        MANIFEST_FILE,
+      ]);
 
       const captured = cliHelper.endLogCapture();
       captured.consoleLogs.length.should.equal(0);
-      captured.consoleWarns.length.should.not.equal(0);
+      captured.consoleWarns.length.should.equal(0);
       captured.consoleErrors.length.should.equal(0);
 
       manifestEntries.length.should.equal(goodFiles.length);
@@ -321,7 +324,7 @@ describe('Build File Manifest', function() {
       manifestEntries.forEach((manifestEntry) => {
         let matchingGoodFile = null;
         goodFiles.forEach((goodFile) => {
-          if (goodFile.file === manifestEntry.url) {
+          if (`/${goodFile.file}` === manifestEntry.url) {
             matchingGoodFile = goodFile;
           }
         });
@@ -330,7 +333,7 @@ describe('Build File Manifest', function() {
           throw new Error('Unable to find matching file for manifest entry: ');
         }
 
-        manifestEntry.url.should.equal(matchingGoodFile.file);
+        manifestEntry.url.should.equal(`/${matchingGoodFile.file}`);
         manifestEntry.revision.should.equal(matchingGoodFile.hash);
       });
     });

--- a/packages/sw-cli/test/build-file-manifest.js
+++ b/packages/sw-cli/test/build-file-manifest.js
@@ -1,6 +1,5 @@
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const path = require('path');
 const cliHelper = require('./helpers/cli-test-helper.js');
 const errors = require('../src/lib/errors.js');
 const constants = require('../src/lib/constants.js');

--- a/packages/sw-cli/test/end-to-end.js
+++ b/packages/sw-cli/test/end-to-end.js
@@ -95,7 +95,8 @@ describe('Test Example Projects', function() {
 
         const expectedFileIndex = expectedFiles.indexOf(details.url);
         if (expectedFileIndex === -1) {
-          throw new Error(`Unexpected file in in manifest: '${details.url}'`);
+          console.log(expectedFiles);
+          throw new Error(`Unexpected file in manifest: '${details.url}'`);
         }
 
         expectedFiles.splice(expectedFileIndex, 1);

--- a/packages/sw-cli/test/end-to-end.js
+++ b/packages/sw-cli/test/end-to-end.js
@@ -75,7 +75,7 @@ describe('Test Example Projects', function() {
         ignore: `${exampleProject}/${manifestName}`,
       });
       expectedFiles = expectedFiles.map((file) => {
-        return `/${path.relative(exampleProject, file)}`;
+        return `/${path.relative(exampleProject, file).replace(path.sep, '/')}`;
       });
 
       const fileManifestOutput = injectedSelf['__file_manifest'];


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

This PR should filter out the manifest itself from the generated file manifest.

NOTE: This will need re-running on AppVeyor once #129 is landed.
