### PR TITLE
Fixes the stack issue with gulp-documentation

### DIFF
--- a/build-utils.js
+++ b/build-utils.js
@@ -34,6 +34,19 @@ const globPromise = promisify('glob');
 
 const LICENSE_HEADER = fs.readFileSync('LICENSE-HEADER', 'utf8');
 
+const PLUGINS = [
+  rollupBabel({
+    plugins: ['transform-async-to-generator', 'external-helpers'],
+      exclude: 'node_modules/**',
+    }),
+    resolve({
+      jsnext: true,
+      main: true,
+      browser: true,
+    }),
+    commonjs(),
+];
+
 /**
  * Wrapper on top of childProcess.spawn() that returns a promise which rejects
  * when the child process has a non-zero exit code and resolves otherwise.
@@ -140,24 +153,11 @@ function buildJSBundle(options) {
  * @returns {Array.<Object>}
  */
 function generateBuildConfigs(formatToPath, projectDir, moduleName) {
-  const plugins = [
-    rollupBabel({
-      plugins: ['transform-async-to-generator', 'external-helpers'],
-      exclude: 'node_modules/**',
-    }),
-    resolve({
-      jsnext: true,
-      main: true,
-      browser: true,
-    }),
-    commonjs(),
-  ];
-
   // This is shared throughout the full permutation of build configs.
   const baseConfig = {
     rollupConfig: {
       entry: path.join(projectDir, 'src', 'index.js'),
-      plugins,
+      plugins: PLUGINS,
       moduleName,
     },
     projectDir,


### PR DESCRIPTION
Diagnosed through memory snapshot

R: @jeffposnick @addyosmani 

Fixes #149

This is just an initial PR to moving over to new doc site. I am expecting that being able to build all projects and update README's using handlebars will be desired so having current gulp documentation is desirable.
