### PR TITLE
Excludes build.js and 'test/' from exported modules.

### DIFF
--- a/packages/sw-appcache-behavior/package.json
+++ b/packages/sw-appcache-behavior/package.json
@@ -10,6 +10,10 @@
     "manifest",
     "app cache"
   ],
+  "files": [
+    "src",
+    "build"
+  ],
   "author": {
     "name": "Jeff Posnick",
     "email": "jeffy@google.com",

--- a/packages/sw-background-sync-queue/package.json
+++ b/packages/sw-background-sync-queue/package.json
@@ -9,6 +9,10 @@
     "queue",
     "sw-fw"
   ],
+  "files": [
+    "src",
+    "build"
+  ],
   "author": "Google's Web DevRel Team",
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",

--- a/packages/sw-cli/package.json
+++ b/packages/sw-cli/package.json
@@ -17,6 +17,10 @@
   "bin": {
     "sw-cli": "src/bin/index.js"
   },
+  "files": [
+    "src",
+    "build"
+  ],
   "engines": {
     "node": ">=4.0.0"
   },

--- a/packages/sw-lib/package.json
+++ b/packages/sw-lib/package.json
@@ -9,6 +9,10 @@
     "fetch requests",
     "offline"
   ],
+  "files": [
+    "src",
+    "build"
+  ],
   "main": "build/sw-lib.min.js",
   "module": "build/sw-lib.min.mjs",
   "jsnext:main": "build/sw-lib.min.mjs",

--- a/packages/sw-offline-google-analytics/package.json
+++ b/packages/sw-offline-google-analytics/package.json
@@ -17,5 +17,9 @@
   "repository": "googlechrome/sw-helpers",
   "bugs": "https://github.com/googlechrome/sw-helpers/issues",
   "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-offline-google-analytics",
-  "main": "build/offline-google-analytics-import.min.js"
+  "main": "build/offline-google-analytics-import.min.js",
+  "files": [
+    "src",
+    "build"
+  ]
 }


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Fixes #137

Just adds a files array to packages that don't currently have one (Mine and Prateeks ;) )
