### PR TITLE
Fetch and cache

### DIFF
--- a/packages/sw-precaching/src/lib/controllers/base-cache-manager.js
+++ b/packages/sw-precaching/src/lib/controllers/base-cache-manager.js
@@ -124,18 +124,18 @@ class BaseCacheManager {
       return;
     }
 
-    let response = await this._requestWrapper.fetch({
-      request: precacheEntry.getNetworkRequest(),
-    });
-    if (response.ok) {
-      const openCache = await this._getCache();
-      await openCache.put(precacheEntry.request, response);
+    try {
+      await this._requestWrapper.fetchAndCache({
+        request: precacheEntry.getNetworkRequest(),
+        waitOnCache: true,
+        cacheKey: precacheEntry.request,
+      });
 
       return this._onEntryCached(precacheEntry);
-    } else {
+    } catch (err) {
       throw ErrorFactory.createError('request-not-cached', {
         message: `Failed to get a cacheable response for ` +
-          `'${precacheEntry.request.url}'`,
+          `'${precacheEntry.request.url}': ${err.message}`,
       });
     }
   }

--- a/packages/sw-precaching/src/lib/controllers/revisioned-cache-manager.js
+++ b/packages/sw-precaching/src/lib/controllers/revisioned-cache-manager.js
@@ -116,14 +116,19 @@ class RevisionedCacheManager extends BaseCacheManager {
    * cached, false otherwise.
    */
   async _isAlreadyCached(precacheEntry) {
+    console.log('-------------------_isAlreadyCached ', precacheEntry.entryID);
+    console.log('cacheName: ', this._cacheName);
+
     const revisionDetails = await
       this._revisionDetailsModel.get(precacheEntry.entryID);
     if (revisionDetails !== precacheEntry.revision) {
+      console.log('isAlreadyCached Exit 1', precacheEntry.entryID);
       return false;
     }
 
     const openCache = await this._getCache();
     const cachedResponse = await openCache.match(precacheEntry.request);
+    console.log('isAlreadyCached Exit 2: ', precacheEntry.entryID, cachedResponse);
     return cachedResponse ? true : false;
   }
 

--- a/packages/sw-precaching/src/lib/controllers/revisioned-cache-manager.js
+++ b/packages/sw-precaching/src/lib/controllers/revisioned-cache-manager.js
@@ -116,19 +116,14 @@ class RevisionedCacheManager extends BaseCacheManager {
    * cached, false otherwise.
    */
   async _isAlreadyCached(precacheEntry) {
-    console.log('-------------------_isAlreadyCached ', precacheEntry.entryID);
-    console.log('cacheName: ', this._cacheName);
-
     const revisionDetails = await
       this._revisionDetailsModel.get(precacheEntry.entryID);
     if (revisionDetails !== precacheEntry.revision) {
-      console.log('isAlreadyCached Exit 1', precacheEntry.entryID);
       return false;
     }
 
     const openCache = await this._getCache();
     const cachedResponse = await openCache.match(precacheEntry.request);
-    console.log('isAlreadyCached Exit 2: ', precacheEntry.entryID, cachedResponse);
     return cachedResponse ? true : false;
   }
 

--- a/packages/sw-precaching/test/browser-unit/cache-testing.js
+++ b/packages/sw-precaching/test/browser-unit/cache-testing.js
@@ -23,8 +23,8 @@ describe('sw-precaching Test Revisioned Caching', function() {
   });
 
   afterEach(function() {
-    // return window.goog.swUtils.cleanState()
-    // .then(deleteIndexedDB);
+    return window.goog.swUtils.cleanState()
+    .then(deleteIndexedDB);
   });
 
   const testCacheEntries = (fileSet) => {

--- a/packages/sw-precaching/test/browser-unit/cache-testing.js
+++ b/packages/sw-precaching/test/browser-unit/cache-testing.js
@@ -23,8 +23,8 @@ describe('sw-precaching Test Revisioned Caching', function() {
   });
 
   afterEach(function() {
-    return window.goog.swUtils.cleanState()
-    .then(deleteIndexedDB);
+    // return window.goog.swUtils.cleanState()
+    // .then(deleteIndexedDB);
   });
 
   const testCacheEntries = (fileSet) => {
@@ -137,7 +137,7 @@ describe('sw-precaching Test Revisioned Caching', function() {
     .then((step1Responses) => {
       return window.goog.swUtils.activateSW(sw2)
       .then((iframe) => {
-        return testFileSet(iframe, sw1, goog.__TEST_DATA['set-1']['step-2']);
+        return testFileSet(iframe, sw2, goog.__TEST_DATA['set-1']['step-2']);
       })
       .then((step2Responses) => {
         compareRevisionedCachedAssets({

--- a/packages/sw-runtime-caching/src/lib/error-factory.js
+++ b/packages/sw-runtime-caching/src/lib/error-factory.js
@@ -20,6 +20,9 @@ const errors = {
     'behavior that implements cacheWillUpdate.',
   'multiple-cache-will-match-behaviors': 'You cannot register more than one ' +
     'behavior that implements cacheWillMatch.',
+  'invalid-reponse-for-caching': 'The fetched response could not be cached ' +
+    'due to an invalid response code, by default only 20X responses can ' +
+    'be cached.',
 };
 
 export default new ErrorFactory(errors);

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -167,14 +167,19 @@ class RequestWrapper {
    * configuring one or more behaviors that implement the `cacheWillUpdate`
    * lifecycle callback.
    *
+   * If the entry isn't cached an error will be thrown.
+   *
    * @param {Object} input
    * @param {Request} input.request The request to fetch.
    * @param {boolean} [input.waitOnCache] `true` means the method should wait
    *        for the cache.put() to complete before returning. The default value
    *        of `false` means return without waiting.
+   * @param {Request} [input.cacheKey] Supply a cacheKey if you wish to cache
+   *        the response against an alternative request to the `request`
+   *        argument.
    * @return {Promise.<Response>} The network response.
    */
-  async fetchAndCache({request, waitOnCache}) {
+  async fetchAndCache({request, waitOnCache, cacheKey}) {
     assert.atLeastOne({request});
 
     let cachingComplete;
@@ -187,31 +192,34 @@ class RequestWrapper {
         {request, response});
     }
 
-    if (cacheable) {
-      const newResponse = response.clone();
-
-      // cacheDelay is a promise that may or may not be used to delay the
-      // completion of this method, depending on the value of `waitOnCache`.
-      cachingComplete = this.getCache().then(async (cache) => {
-        let oldResponse;
-
-        // Only bother getting the old response if the new response isn't opaque
-        // and there's at least one cacheDidUpdateCallbacks. Otherwise, we don't
-        // need it.
-        if (response.type !== 'opaque' &&
-          this.behaviorCallbacks.cacheDidUpdate) {
-          oldResponse = await this.match({request});
-        }
-
-        // Regardless of whether or not we'll end up invoking
-        // cacheDidUpdateCallbacks, wait until the cache is updated.
-        await cache.put(request, newResponse);
-
-        for (let callback of (this.behaviorCallbacks.cacheDidUpdate || [])) {
-          callback({cacheName: this.cacheName, oldResponse, newResponse});
-        }
-      });
+    if (!cacheable) {
+      throw ErrorFactory.createError('invalid-reponse-for-caching');
     }
+
+    const newResponse = response.clone();
+
+    // cacheDelay is a promise that may or may not be used to delay the
+    // completion of this method, depending on the value of `waitOnCache`.
+    cachingComplete = this.getCache().then(async (cache) => {
+      let oldResponse;
+
+      // Only bother getting the old response if the new response isn't opaque
+      // and there's at least one cacheDidUpdateCallbacks. Otherwise, we don't
+      // need it.
+      if (response.type !== 'opaque' &&
+        this.behaviorCallbacks.cacheDidUpdate) {
+        oldResponse = await this.match({request});
+      }
+
+      // Regardless of whether or not we'll end up invoking
+      // cacheDidUpdateCallbacks, wait until the cache is updated.
+      const cacheRequest = cacheKey || request;
+      await cache.put(cacheRequest, newResponse);
+
+      for (let callback of (this.behaviorCallbacks.cacheDidUpdate || [])) {
+        callback({cacheName: this.cacheName, oldResponse, newResponse});
+      }
+    });
 
     // Only conditionally await the caching completion, giving developers the
     // option of returning early for, e.g., read-through-caching scenarios.


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Fixes #178 

The one behavior I'm unsure of is how to highlight that the cache of the response didn't occur because it was an invalid response.

For now I've implemented a check for (!cacheable && waitOnCache) => i.e. the developer wanted to wait on the cache.put() that is never going to happen so throw. Not the nicest solution, but not sure how else to approach this use case.
