### PR TITLE
Test harness template, along with migration of sw-broadcast-cache-upd…

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-rollup": "^2.5.1",
     "gulp-sourcemaps": "^2.4.0",
     "gulp-spawn-mocha": "^3.1.0",
+    "handlebars": "^4.0.6",
     "jsdoc-strip-async-await": "^0.1.0",
     "lerna": "2.0.0-beta.30",
     "minimist": "^1.2.0",

--- a/packages/sw-broadcast-cache-update/test/automated-test-suite.js
+++ b/packages/sw-broadcast-cache-update/test/automated-test-suite.js
@@ -34,7 +34,7 @@ describe(`${packageName} Browser Tests`, function() {
 
   // Set up the web server before running any tests in this suite.
   before(() => testServer.start('.').then((portNumber) => {
-    testHarnessUrl = `http://localhost:${portNumber}/packages/${packageName}/test/browser/testHarness`;
+    testHarnessUrl = `http://localhost:${portNumber}/packages/${packageName}/test/browser/harness`;
   }));
 
   // Kill the web server once all tests are complete.

--- a/packages/sw-broadcast-cache-update/test/automated-test-suite.js
+++ b/packages/sw-broadcast-cache-update/test/automated-test-suite.js
@@ -4,14 +4,14 @@
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-*/
+ */
 
 const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
@@ -30,11 +30,11 @@ describe(`${packageName} Browser Tests`, function() {
   this.timeout(TIMEOUT);
 
   let globalDriverBrowser;
-  let baseTestUrl;
+  let testHarnessUrl;
 
   // Set up the web server before running any tests in this suite.
   before(() => testServer.start('.').then((portNumber) => {
-    baseTestUrl = `http://localhost:${portNumber}/packages/${packageName}`;
+    testHarnessUrl = `http://localhost:${portNumber}/packages/${packageName}/test/browser/testHarness`;
   }));
 
   // Kill the web server once all tests are complete.
@@ -50,7 +50,7 @@ describe(`${packageName} Browser Tests`, function() {
         .then(() => swTestingHelpers.mochaUtils.startWebDriverMochaTests(
           assistantDriver.getPrettyName(),
           globalDriverBrowser,
-          `${baseTestUrl}/test/browser/`
+          testHarnessUrl
         )).then((testResults) => {
           console.log(swTestingHelpers.mochaUtils.prettyPrintResults(testResults));
           if (testResults.failed.length > 0) {
@@ -67,7 +67,7 @@ describe(`${packageName} Browser Tests`, function() {
           console.log(`Skipping Opera <= 43 due to driver issues.`);
           return;
         }
-        // fall through
+      // fall through
       case 'chrome':
       case 'firefox':
         setupTestSuite(browser);

--- a/packages/sw-broadcast-cache-update/test/automated-test-suite.js
+++ b/packages/sw-broadcast-cache-update/test/automated-test-suite.js
@@ -34,7 +34,7 @@ describe(`${packageName} Browser Tests`, function() {
 
   // Set up the web server before running any tests in this suite.
   before(() => testServer.start('.').then((portNumber) => {
-    testHarnessUrl = `http://localhost:${portNumber}/packages/${packageName}/test/browser/harness`;
+    testHarnessUrl = `http://localhost:${portNumber}/__test/mocha/${packageName}`;
   }));
 
   // Kill the web server once all tests are complete.

--- a/templates/test-harness.hbs
+++ b/templates/test-harness.hbs
@@ -10,11 +10,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+<!-- This file is served via /packages/<pkg>/test/browser/testHarness
+     See utils/service-instance.js for the serving logic. -->
 <html>
   <head>
     <meta charset="utf-8">
-    <title>SW Helpers Tests</title>
-    <link href="/node_modules/mocha/mocha.css" rel="stylesheet" />
+    <title>Test Harness: {{pkg}}</title>
+    <link href="/node_modules/mocha/mocha.css" rel="stylesheet">
 
     <!--
       iframes are used to manage service worker scoping.
@@ -49,9 +51,10 @@
       const expect = chai.expect;
     </script>
 
-    <!-- In browser test scripts should be added to the page here -->
-    <script src="register-unit-tests.js"></script>
-    <script src="end-to-end.js"></script>
+    <!-- Package-specific tests matching packages/<pkg>/test/browser/*.js -->
+    {{#each scripts}}
+      <script src="{{this}}"></script>
+    {{/each}}
 
     <script>
       (function() {

--- a/templates/test-harness.hbs
+++ b/templates/test-harness.hbs
@@ -10,12 +10,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!-- This file is served via /packages/<pkg>/test/browser/testHarness
+<!-- This file is served via /__test/mocha/<pkg>
      See utils/service-instance.js for the serving logic. -->
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Test Harness: {{pkg}}</title>
+    <title>Mocha Test Harness: {{pkg}}</title>
+    <base href="/packages/{{pkg}}/test/browser/">
     <link href="/node_modules/mocha/mocha.css" rel="stylesheet">
 
     <!--

--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -71,7 +71,7 @@ class ServerInstance {
     // Harness to kick off all the in-browser tests for a given package.
     // It will pick up a list of all the top-level .js files and automatically
     // inject them into the HTML as <script> tags.
-    this._app.get('/packages/:pkg/test/browser/harness', function(req, res) {
+    this._app.get('/__test/mocha/:pkg', function(req, res) {
       const pkg = req.params.pkg;
       const pattern = `packages/${pkg}/test/browser/*.js`;
       const scripts = glob.sync(pattern).map((script) => `/${script}`);
@@ -86,6 +86,18 @@ class ServerInstance {
       const html = template({scripts, pkg});
 
       res.send(html);
+    });
+
+    // Redirect /packages/:pkg/test/browser/ to the /__test/mocha/:pkg templated
+    // page, but only if there's no /packages/:pkg/test/browser/index.html
+    this._app.get('/packages/:pkg/test/browser/', function(req, res, next) {
+      const index = path.join(__dirname, '..', 'packages', req.params.pkg,
+        'test', 'browser', 'index.html');
+      if (fs.existsSync(index)) {
+        next();
+      } else {
+        res.redirect(301, `/__test/mocha/${req.params.pkg}`);
+      }
     });
   }
 

--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -71,10 +71,10 @@ class ServerInstance {
     // Harness to kick off all the in-browser tests for a given package.
     // It will pick up a list of all the top-level .js files and automatically
     // inject them into the HTML as <script> tags.
-    this._app.get('/packages/:pkg/test/browser/testHarness', function(req, res) {
+    this._app.get('/packages/:pkg/test/browser/harness', function(req, res) {
       const pkg = req.params.pkg;
       const pattern = `packages/${pkg}/test/browser/*.js`;
-      const scripts = glob.sync(pattern).map(script => `/${script}`);
+      const scripts = glob.sync(pattern).map((script) => `/${script}`);
 
       if (scripts.length === 0) {
         throw Error(`No test scripts match the pattern '${pattern}'.`);


### PR DESCRIPTION
We discussed moving some of the HTML test harness logic to a template. Here's one approach—let me know what you think, @gauntface. Happy to make change or just abandon if you're not in favor. It does simplify setting up new package tests at the expense of extra "magic" that might make it more inaccessible to new developers.

I've just moved over one package's tests to use the template, but would theoretically move over the rest if we want to go with this approach.