### PR TITLE
Minor edits.

### DIFF
--- a/packages/sw-cli/src/lib/generate-sw.js
+++ b/packages/sw-cli/src/lib/generate-sw.js
@@ -7,7 +7,7 @@ const generateGlobPattern = require('./utils/generate-glob-pattern');
 const writeServiceWorker = require('./write-sw');
 
 /**
- * This method will generate a working Service Worker with an inlined
+ * Generate a working service worker with an inlined
  * file manifest.
  * @return {Promise} The promise returned here will be used to exit the
  * node process cleanly or not.


### PR DESCRIPTION
This is related to https://github.com/GoogleChrome/sw-helpers/pull/199, which I should have looked at when it came through.

I don't understand what this promise returns. It should say something like 'resolves to void', 'resolves to a boolean value indicating...', or 'resolves to a reference to the new `Widget` instance, for example.

R: @jeffposnick @addyosmani @gauntface

Fixes #*issue number*

*Description of what's changed/fixed.*

*Please ensure that `gulp lint test` passes locally prior to filing a PR!*
