### PR TITLE
Add ES2015 .mjs module output to the sw-lib build process

### DIFF
--- a/packages/sw-lib/build.js
+++ b/packages/sw-lib/build.js
@@ -17,6 +17,7 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
+  es: pkg['jsnext:main'],
   umd: pkg.main,
 }, __dirname, 'goog.swlib');
 


### PR DESCRIPTION
R: @gauntface

Adding in `.mjs` output seems to work fine, and it's needed to consume `sw-lib` as an ES module.

Hopefully this was just an oversight and there isn't a technical reason why we can't output an ES module here.