### PR TITLE
Adds a format option to writeFileManifest(), defaulting to 'iife'

### DIFF
--- a/packages/sw-build/src/lib/errors.js
+++ b/packages/sw-build/src/lib/errors.js
@@ -47,4 +47,6 @@ module.exports = {
     'strings or JavaScript objects containing a url parameter.',
   'invalid-generate-file-manifest-arg': 'The input to generateFileManifest() ' +
     'must be an Object.',
+  'invalid-manifest-format': `The value of the 'format' option passed to
+    generateFileManifest() must be either 'iife' (the default) or 'es'.`,
 };

--- a/packages/sw-build/src/lib/generate-file-manifest.js
+++ b/packages/sw-build/src/lib/generate-file-manifest.js
@@ -30,10 +30,8 @@ const errors = require('./errors');
  * generating the build manifest.
  * @param {String|Array<String>} input.globIgnores Patterns to exclude when
  * generating the build manifest.
- * @param {String} [input.format] Either [`'iife'`](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
- * (the default) or `'es'`. If you plan on reading in the manifest from your
- * service worker via [`importScripts()`](), then use `'iife'`. If you plan on
- * reading in the manifest as an imported ES2015 module, use `'es'`.
+ * @param {String} [input.format] Default format is [`'iife'`](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression), but also
+ * accepts `'es'`, which outputs an ES2015 module.
  * @return {Promise} Resolves once the service worker has been generated
  * with a precache list.
  *

--- a/packages/sw-build/src/lib/generate-file-manifest.js
+++ b/packages/sw-build/src/lib/generate-file-manifest.js
@@ -3,21 +3,23 @@ const writeFileManifest = require('./utils/write-file-manifest');
 const errors = require('./errors');
 
 /**
- * @example <caption>Generate a service worker for a project.</caption>
+ * @example <caption>Generate a build manifest of static assets, which could
+ * then be used with a service worker.</caption>
  * const swBuild = require('sw-build');
  *
  * swBuild.generateFileManifest({
  *   dest: './build/manifest.js'
  *   rootDirectory: './build/',
  *   globPatterns: ['**\/*.{html,js,css}'],
- *   globIgnores: ['admin.html']
+ *   globIgnores: ['admin.html'],
+ *   format: 'iife', // alternatively, use 'es'
  * })
  * .then(() => {
  *   console.log('Build Manifest generated.');
  * });
  *
  * This method will generate a file manifest that can be used in a service
- * worker for caching assets offline..
+ * worker for caching assets offline.
  * @param {Object} input
  * @param {String} input.dest The name and path you wish to write your
  * manifest file to.
@@ -28,6 +30,10 @@ const errors = require('./errors');
  * generating the build manifest.
  * @param {String|Array<String>} input.globIgnores Patterns to exclude when
  * generating the build manifest.
+ * @param {String} [input.format] Either [`'iife'`](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
+ * (the default) or `'es'`. If you plan on reading in the manifest from your
+ * service worker via [`importScripts()`](), then use `'iife'`. If you plan on
+ * reading in the manifest as an imported ES2015 module, use `'es'`.
  * @return {Promise} Resolves once the service worker has been generated
  * with a precache list.
  *
@@ -47,7 +53,7 @@ const generateFileManifest = (input) => {
   const fileEntries = getFileManifestEntries({
     rootDirectory, globPatterns, globIgnores,
   });
-  return writeFileManifest(dest, fileEntries);
+  return writeFileManifest(dest, fileEntries, input.format);
 };
 
 module.exports = generateFileManifest;

--- a/packages/sw-build/src/lib/templates/file-manifest-es2015.tmpl
+++ b/packages/sw-build/src/lib/templates/file-manifest-es2015.tmpl
@@ -1,0 +1,2 @@
+// This uses the ES2015 module format: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
+export default <%= JSON.stringify(manifestEntries) %>;

--- a/packages/sw-build/src/lib/utils/write-file-manifest.js
+++ b/packages/sw-build/src/lib/utils/write-file-manifest.js
@@ -5,7 +5,13 @@ const template = require('lodash.template');
 
 const errors = require('../errors');
 
-const writeFileManifest = (manifestFilePath, manifestEntries) => {
+const defaultFormat = 'iife';
+const formatsToTemplates = {
+  iife: 'file-manifest.js.tmpl',
+  es: 'file-manifest-es2015.tmpl',
+};
+
+const writeFileManifest = (manifestFilePath, manifestEntries, format) => {
   if (!manifestFilePath || typeof manifestFilePath !== 'string' ||
     manifestFilePath.length === 0) {
     return Promise.reject(new Error(errors['invalid-manifest-path']));
@@ -13,6 +19,11 @@ const writeFileManifest = (manifestFilePath, manifestEntries) => {
 
   if (!manifestEntries || !(manifestEntries instanceof Array)) {
     return Promise.reject(new Error(errors['invalid-manifest-entries']));
+  }
+
+  format = format || defaultFormat;
+  if (!(format in formatsToTemplates)) {
+    return Promise.reject(new Error(errors['invalid-manifest-format']));
   }
 
   for (let i = 0; i < manifestEntries.length; i++) {
@@ -33,7 +44,7 @@ const writeFileManifest = (manifestFilePath, manifestEntries) => {
   }
 
   const templatePath = path.join(__dirname, '..', 'templates',
-    'file-manifest.js.tmpl');
+    formatsToTemplates[format]);
 
   return new Promise((resolve, reject) => {
     mkdirp(path.dirname(manifestFilePath), (err) => {

--- a/packages/sw-build/test/lib-write-file-manifest.js
+++ b/packages/sw-build/test/lib-write-file-manifest.js
@@ -6,6 +6,19 @@ require('chai').should();
 
 describe('src/lib/utils/write-file-manifest.js', function() {
   const INJECTED_ERROR = new Error('Injected Error');
+  const FAKE_PATH = 'fake-path/manifest-name.js';
+
+  it('should handle a bad manifest format', function() {
+    return writeFileManifest(FAKE_PATH, [], 'invalid-format')
+      .then(() => {
+        throw new Error('Expected error to be thrown.');
+      })
+      .catch((err) => {
+        if (err.message !== errors['invalid-manifest-format']) {
+          throw new Error('Unexpected error thrown: ' + err.message);
+        }
+      });
+  });
 
   it('should handle bad manifest path', function() {
     const badInputs = [
@@ -73,7 +86,7 @@ describe('src/lib/utils/write-file-manifest.js', function() {
       },
     });
 
-    return writeFileManifest('fake-path/manifest-name.js', [])
+    return writeFileManifest(FAKE_PATH, [])
     .then(() => {
       throw new Error('Expected an error.');
     })
@@ -96,7 +109,7 @@ describe('src/lib/utils/write-file-manifest.js', function() {
       },
     });
 
-    return writeFileManifest('fake-path/manifest-name.js', [])
+    return writeFileManifest(FAKE_PATH, [])
     .then(() => {
       throw new Error('Expected an error.');
     })
@@ -122,7 +135,7 @@ describe('src/lib/utils/write-file-manifest.js', function() {
       },
     });
 
-    return writeFileManifest('fake-path/manifest-name.js', [])
+    return writeFileManifest(FAKE_PATH, [])
     .then(() => {
       throw new Error('Expected an error.');
     })
@@ -153,7 +166,7 @@ describe('src/lib/utils/write-file-manifest.js', function() {
       },
     });
 
-    return writeFileManifest('fake-path/manifest-name.js', [])
+    return writeFileManifest(FAKE_PATH, [])
     .then(() => {
       throw new Error('Expected an error.');
     })

--- a/packages/sw-build/test/lib-write-file-manifest.js
+++ b/packages/sw-build/test/lib-write-file-manifest.js
@@ -9,6 +9,7 @@ describe('src/lib/utils/write-file-manifest.js', function() {
   const FAKE_PATH = 'fake-path/manifest-name.js';
 
   it('should handle a bad manifest format', function() {
+    const writeFileManifest = require('../src/lib/utils/write-file-manifest');
     return writeFileManifest(FAKE_PATH, [], 'invalid-format')
       .then(() => {
         throw new Error('Expected error to be thrown.');


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #221 

I've added an extra test to confirm that the exception we expect is thrown when a bad format is passed in. I didn't add an extra test to actually confirm that the output of the `writeFileManifest({format: 'es'})` command is a valid ES2015 file with the expected entries, though. I didn't see where the equivalent test was to confirm that the previous output was valid—if you could point me in the right direction, @gauntface, I'll add that test to this PR.