### PR TITLE
Make the Errors generated by assert more useful.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -15,10 +15,12 @@
 
 /* eslint-disable require-jsdoc */
 
+import ErrorStackParser from 'error-stack-parser';
+
 function atLeastOne(object) {
   const parameters = Object.keys(object);
   if (!parameters.some((parameter) => object[parameter] !== undefined)) {
-    throw Error('Please set at least one of the following parameters: ' +
+    throwError('Please set at least one of the following parameters: ' +
       parameters.map((p) => `'${p}'`).join(', '));
   }
 }
@@ -27,24 +29,24 @@ function hasMethod(object, expectedMethod) {
   const parameter = Object.keys(object).pop();
   const type = typeof object[parameter][expectedMethod];
   if (type !== 'function') {
-    throw Error(`The '${parameter}' parameter must be an object that exposes ` +
-      `a '${expectedMethod}' method.`);
+    throwError(`The '${parameter}' parameter must be an object that exposes a
+      '${expectedMethod}' method.`);
   }
 }
 
 function isInstance(object, expectedClass) {
   const parameter = Object.keys(object).pop();
   if (!(object[parameter] instanceof expectedClass)) {
-    throw Error(`The '${parameter}' parameter must be an instance of ` +
-      `'${expectedClass.name}'`);
+    throwError(`The '${parameter}' parameter must be an instance of
+      '${expectedClass.name}'`);
   }
 }
 
 function isOneOf(object, values) {
   const parameter = Object.keys(object).pop();
   if (!values.includes(object[parameter])) {
-    throw Error(`The '${parameter}' parameter must be set to one of the ` +
-      `following: ${values}`);
+    throwError(`The '${parameter}' parameter must be set to one of the
+      following: ${values}`);
   }
 }
 
@@ -52,8 +54,8 @@ function isType(object, expectedType) {
   const parameter = Object.keys(object).pop();
   const actualType = typeof object[parameter];
   if (actualType !== expectedType) {
-    throw Error(`The '${parameter}' parameter has the wrong type. ` +
-      `(Expected: ${expectedType}, actual: ${actualType})`);
+    throwError(`The '${parameter}' parameter has the wrong type. (Expected:
+      ${expectedType}, actual: ${actualType})`);
   }
 }
 
@@ -66,9 +68,27 @@ function isValue(object, expectedValue) {
   const parameter = Object.keys(object).pop();
   const actualValue = object[parameter];
   if (actualValue !== expectedValue) {
-    throw Error(`The '${parameter}' parameter has the wrong value. ` +
-      `(Expected: ${expectedValue}, actual: ${actualValue})`);
+    throwError(`The '${parameter}' parameter has the wrong value. (Expected: 
+      ${expectedValue}, actual: ${actualValue})`);
   }
+}
+
+function throwError(message) {
+  const error = new Error(message);
+  const stackFrames = ErrorStackParser.parse(error);
+
+  // If, for some reason, we don't have all the stack information we need,
+  // we'll just end up throwing a basic Error.
+  if (stackFrames.length >= 3) {
+    // Assuming we have the stack frames, set the message to include info
+    // about what the underlying method was, and set the name to reflect
+    // the assertion type that failed.
+    error.message = `Invalid call to ${stackFrames[2].functionName}() — ` +
+      message.replace(/\s+/g, ' ');
+    error.name = stackFrames[1].functionName.replace(/^Object/, 'assert');
+  }
+
+  throw error;
 }
 
 export default {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chromedriver": "^2.26.1",
     "clear-require": "^2.0.0",
     "cookie-parser": "^1.4.3",
+    "error-stack-parser": "^2.0.0",
     "eslint-config-google": "^0.7.0",
     "express": "^4.14.0",
     "fs-extra": "^2.0.0",

--- a/utils/build.js
+++ b/utils/build.js
@@ -129,7 +129,13 @@ function buildJSBundle(options) {
       .pipe(sourcemaps.init())
       .pipe(rollup(options.rollupConfig))
       .pipe(gulpif(options.minify, babel({
-        presets: ['babili', {comments: false}],
+        presets: [
+          ['babili', {
+            comments: false,
+            keepFnName: true,
+            keepClassName: true,
+          }],
+        ],
       })))
       .pipe(header(LICENSE_HEADER))
       .pipe(rename(outputName))


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #98 

This might be a little controversial, so feel free to push back.

The changes here don't end up using `ErrorFactory` in the `assert` module. I think they add functionality to `assert` that brings it on par with what you'd get with `ErrorFactory`, without the overhead of explicitly maintaining a large mapping of error identifiers. Folks are obviously free to continue using `ErrorFactory` where appropriate, e.g. in contexts that assertions don't make sense.

With this change in place, failing assertions that were defined like:

```js
class Router {
  registerRoutes({routes} = {}) {
    assert.isInstance({routes}, Array);
    // ...
  }
}
```

produce `Error` objects that have fields like:

```json
{
  "message": "Invalid call to Router.registerRoutes() — The 'routes' parameter must be an instance of 'Array'",
  "name": "assert.isInstance"
}
```

The `message` is set to something meaningful, including the underlying method that triggered the assertion failure, and featuring unmangled method/class names.

The `name` is set to the specific type of assertion that failed—`assert.isInstance`, `assert.atLeastOne`, etc.—meaning that you can use the unit testing pattern of checking `ex.name` to ensure that an expected error is thrown (rather than an unexpected or generic error).

We can theoretically extend this code to automatically include a URL pointing to the specific documentation for the method that failed—i.e. map `Router.registerRoutes()` to https://googlechrome.github.io/sw-helpers/reference-docs/stable/v0.0.8/module-sw-routing.Router.html#registerRoutes, but I haven't tackled that yet.