### PR TITLE
Adds the NavigationRoute class

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -85,7 +85,7 @@ function throwError(message) {
     // the assertion type that failed.
     error.message = `Invalid call to ${stackFrames[2].functionName}() — ` +
       message.replace(/\s+/g, ' ');
-    error.name = stackFrames[1].functionName.replace(/^Object/, '');
+    error.name = stackFrames[1].functionName.replace(/^Object\./, '');
   }
 
   throw error;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -85,7 +85,7 @@ function throwError(message) {
     // the assertion type that failed.
     error.message = `Invalid call to ${stackFrames[2].functionName}() — ` +
       message.replace(/\s+/g, ' ');
-    error.name = stackFrames[1].functionName.replace(/^Object/, 'assert');
+    error.name = stackFrames[1].functionName.replace(/^Object/, '');
   }
 
   throw error;

--- a/packages/sw-routing/src/index.js
+++ b/packages/sw-routing/src/index.js
@@ -22,12 +22,14 @@
  */
 
 import ExpressRoute from './lib/express-route';
+import NavigationRoute from './lib/navigation-route';
 import RegExpRoute from './lib/regexp-route';
 import Route from './lib/route';
 import Router from './lib/router';
 
 export {
   ExpressRoute,
+  NavigationRoute,
   RegExpRoute,
   Route,
   Router,

--- a/packages/sw-routing/src/lib/navigation-route.js
+++ b/packages/sw-routing/src/lib/navigation-route.js
@@ -1,0 +1,81 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import Route from './route';
+import assert from '../../../../lib/assert';
+
+/**
+ * NavigationRoute is a helper class to create a [`Route`]{@link Route}
+ * that matches browser navigation requests, i.e. requests for a page.
+ *
+ * It will only match incoming requests whose [`mode`](https://fetch.spec.whatwg.org/#concept-request-mode)
+ * is set to `navigate`.
+ *
+ * You can optionally only apply this route to a subset of navigation requests
+ * by using one or both of the `blacklist` and `whitelist` parameters. If
+ * both lists are provided, and there's a navigation to a URL which matches
+ * both, then the blacklist will take precedence and the request will not be
+ * matched by this route. The regular expressions in `whitelist` and `blacklist`
+ * are matched against the [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname)
+ * portion of the requested URL.
+ *
+ * To match all navigations, use a `whitelist` array containing a RegExp that
+ * matches everything, i.e. `[/./]`.
+ *
+ * @memberof module:sw-routing
+ * @extends Route
+ *
+ * @example
+ * // Any navigation requests that match the whitelist (i.e. URLs whose path
+ * // starts with /article/) will be handled with the cache entry for
+ * // app-shell.html.
+ * const route = new goog.routing.NavigationRoute({
+ *   whitelist: [new RegExp('^/article/')],
+ *   handler: {handle: () => caches.match('app-shell.html')},
+ * });
+ *
+ * const router = new goog.routing.Router();
+ * router.registerRoute({route});
+ */
+class NavigationRoute extends Route {
+  /**
+   * Constructor for NavigationRoute.
+   *
+   * @param {Object} input
+   * @param {Array<RegExp>} input.whitelist If any of these patterns match,
+   * the route will handle the request (assuming the blacklist doesn't match).
+   * @param {Array<RegExp>} [input.blacklist] If any of these patterns match,
+   * the route will not handle the request (even if a whitelist entry matches).
+   * @param {function} input.handler The handler to manage the response.
+   */
+  constructor({whitelist, blacklist, handler} = {}) {
+    assert.isInstance({whitelist}, Array);
+    if (blacklist) {
+      assert.isInstance({blacklist}, Array);
+    } else {
+      blacklist = [];
+    }
+
+    const match = ({event, url}) => {
+      return event.request.mode === 'navigate' &&
+        whitelist.some((regExp) => regExp.test(url.pathname)) &&
+        !blacklist.some((regExp) => regExp.test(url.pathname));
+    };
+
+    super({match, handler, method: 'GET'});
+  }
+}
+
+export default NavigationRoute;

--- a/packages/sw-routing/src/lib/route.js
+++ b/packages/sw-routing/src/lib/route.js
@@ -81,6 +81,7 @@ class Route {
    */
   constructor({match, handler, method} = {}) {
     assert.isType({match}, 'function');
+    assert.isType({handler}, 'object');
     assert.hasMethod({handler}, 'handle');
 
     this.match = match;

--- a/packages/sw-routing/test/browser/end-to-end.js
+++ b/packages/sw-routing/test/browser/end-to-end.js
@@ -38,6 +38,19 @@ describe('End to End Test of ExpressRoute', function() {
   });
 });
 
+describe('End to End Test of NavigationRoute', function() {
+  it(`should work properly when there's a navigation matching the whitelist`, function(callback) {
+    goog.swUtils.activateSW('../static/navigation-route.js')
+      .then((iframe) => {
+        iframe.addEventListener('load', () => {
+          expect(iframe.contentWindow.document.body.innerText).to.equal('navigation response');
+          callback();
+        });
+        iframe.src = iframe.src + '/navigation';
+      });
+  });
+});
+
 describe('End to End Test of Route', function() {
   it('should work properly when there are multiple routes, matching different HTTP methods', function() {
     return goog.swUtils.activateSW('../static/route.js')

--- a/packages/sw-routing/test/browser/end-to-end.js
+++ b/packages/sw-routing/test/browser/end-to-end.js
@@ -46,6 +46,8 @@ describe('End to End Test of NavigationRoute', function() {
           expect(iframe.contentWindow.document.body.innerText).to.equal('navigation response');
           callback();
         });
+        // Modifying the .src of an iframe will trigger a navigation. You can't
+        // trigger a navigation via fetch().
         iframe.src = iframe.src + '/navigation';
       });
   });

--- a/packages/sw-routing/test/browser/register-unit-tests.js
+++ b/packages/sw-routing/test/browser/register-unit-tests.js
@@ -5,6 +5,7 @@ describe('Service Worker Unit Test Registration', function() {
     'route.js',
     'express-route.js',
     'regexp-route.js',
+    'navigation-route.js',
   ].map((script) => `${pathPrefix}${script}`);
 
   swUnitTests.forEach(function(swUnitTestPath) {

--- a/packages/sw-routing/test/static/navigation-route.js
+++ b/packages/sw-routing/test/static/navigation-route.js
@@ -1,0 +1,16 @@
+/* global goog */
+
+importScripts('/packages/sw-routing/build/sw-routing.js');
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
+
+const route = new goog.routing.NavigationRoute({
+  whitelist: [new RegExp('navigation$')],
+  handler: {
+    handle: () => Promise.resolve(new Response('navigation response')),
+  },
+});
+
+const router = new goog.routing.Router();
+router.registerRoute({route});

--- a/packages/sw-routing/test/sw/namespace.js
+++ b/packages/sw-routing/test/sw/namespace.js
@@ -13,6 +13,7 @@ mocha.setup({
 
 const exportedClasses = [
   'ExpressRoute',
+  'NavigationRoute',
   'RegExpRoute',
   'Route',
   'Router',

--- a/packages/sw-routing/test/sw/navigation-route.js
+++ b/packages/sw-routing/test/sw/navigation-route.js
@@ -30,7 +30,6 @@ describe('Test of the NavigationRoute class', function() {
     } catch(err) {
       thrownError = err;
     }
-
     expect(thrownError).to.exist;
     expect(thrownError.name).to.equal('assert.isInstance');
   });
@@ -42,7 +41,6 @@ describe('Test of the NavigationRoute class', function() {
     } catch(err) {
       thrownError = err;
     }
-
     expect(thrownError).to.exist;
     expect(thrownError.name).to.equal('assert.isInstance');
   });
@@ -54,7 +52,6 @@ describe('Test of the NavigationRoute class', function() {
     } catch(err) {
       thrownError = err;
     }
-
     expect(thrownError).to.exist;
     expect(thrownError.name).to.equal('assert.isType');
 
@@ -63,7 +60,6 @@ describe('Test of the NavigationRoute class', function() {
     } catch(err) {
       thrownError = err;
     }
-
     expect(thrownError).to.exist;
     expect(thrownError.name).to.equal('assert.hasMethod');
   });
@@ -75,7 +71,6 @@ describe('Test of the NavigationRoute class', function() {
     } catch(err) {
       thrownError = err;
     }
-
     expect(thrownError).to.exist;
     expect(thrownError.name).to.equal('assert.isInstance');
   });

--- a/packages/sw-routing/test/sw/navigation-route.js
+++ b/packages/sw-routing/test/sw/navigation-route.js
@@ -31,7 +31,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('assert.isInstance');
+    expect(thrownError.name).to.equal('isInstance');
   });
 
   it(`should throw when NavigationRoute() is called without a valid whitelist`, function() {
@@ -42,7 +42,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('assert.isInstance');
+    expect(thrownError.name).to.equal('isInstance');
   });
 
   it(`should throw when NavigationRoute() is called without a valid handler`, function() {
@@ -53,7 +53,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('assert.isType');
+    expect(thrownError.name).to.equal('isType');
 
     try {
       new goog.routing.NavigationRoute({whitelist, handler: invalidHandler});
@@ -61,7 +61,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('assert.hasMethod');
+    expect(thrownError.name).to.equal('hasMethod');
   });
 
   it(`should throw when NavigationRoute() is called with an invalid blacklist`, function() {
@@ -72,7 +72,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('assert.isInstance');
+    expect(thrownError.name).to.equal('isInstance');
   });
 
   it(`should not throw when NavigationRoute() is called with valid whitelist and handler parameters`, function() {

--- a/packages/sw-routing/test/sw/navigation-route.js
+++ b/packages/sw-routing/test/sw/navigation-route.js
@@ -1,0 +1,110 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-routing/build/sw-routing.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('Test of the NavigationRoute class', function() {
+  const path = '/test/path';
+  const whitelist = [new RegExp(path)];
+  const blacklist = [new RegExp(path)];
+  const handler = {handle: () => {}};
+  const event = {request: {mode: 'navigate'}};
+
+  const invalidHandler = {};
+  const invalidBlacklist = 'invalid';
+  const invalidWhitelist = 'invalid';
+  const invalidEvent = {request: {mode: 'cors'}};
+
+  it(`should throw when NavigationRoute() is called without any parameters`, function() {
+    let thrownError = null;
+    try {
+      new goog.routing.NavigationRoute();
+    } catch(err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('assert.isInstance');
+  });
+
+  it(`should throw when NavigationRoute() is called without a valid whitelist`, function() {
+    let thrownError = null;
+    try {
+      new goog.routing.NavigationRoute({whitelist: invalidWhitelist});
+    } catch(err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('assert.isInstance');
+  });
+
+  it(`should throw when NavigationRoute() is called without a valid handler`, function() {
+    let thrownError = null;
+    try {
+      new goog.routing.NavigationRoute({whitelist});
+    } catch(err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('assert.isType');
+
+    try {
+      new goog.routing.NavigationRoute({whitelist, handler: invalidHandler});
+    } catch(err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('assert.hasMethod');
+  });
+
+  it(`should throw when NavigationRoute() is called with an invalid blacklist`, function() {
+    let thrownError = null;
+    try {
+      new goog.routing.NavigationRoute({whitelist, handler, blacklist: invalidBlacklist});
+    } catch(err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('assert.isInstance');
+  });
+
+  it(`should not throw when NavigationRoute() is called with valid whitelist and handler parameters`, function() {
+    expect(() => new goog.routing.NavigationRoute({handler, whitelist})).not.to.throw();
+  });
+
+  it(`should match navigation requests for URLs that are in the whitelist`, function() {
+    const url = new URL(path, location);
+    const route = new goog.routing.NavigationRoute({handler, whitelist});
+    expect(route.match({event, url})).to.be.ok;
+  });
+
+  it(`should not match navigation requests for URLs that are in both the whitelist and the blacklist`, function() {
+    const url = new URL(path, location);
+    const route = new goog.routing.NavigationRoute({handler, whitelist, blacklist});
+    expect(route.match({event, url})).to.not.be.ok;
+  });
+
+  it(`should not match navigation requests for URLs that are not in the whitelist`, function() {
+    const url = new URL('/does/not/match', location);
+    const route = new goog.routing.NavigationRoute({handler, whitelist});
+    expect(route.match({event, url})).to.not.be.ok;
+  });
+
+  it(`should not match non-navigation requests for URLs that are in the whitelist`, function() {
+    const url = new URL(path, location);
+    const route = new goog.routing.NavigationRoute({handler, whitelist});
+    expect(route.match({event: invalidEvent, url})).to.not.be.ok;
+  });
+});


### PR DESCRIPTION
R: @addyosmani @gauntface

This adds a new `NavigationRoute` class, fairly close to what's described in #169, which matches when `event.request.mode === 'navigate'` and the URL's pathname is in a whitelist (and not in a blacklist).

This lays the groundwork for App Shell routing. I think the next step would be to take this and add in some logic in `sw-lib` that made use of `NavigationRoute` coming after the route that matches precached assets, and allowed the developer to cleanly specify the URL that corresponds to their App Shell HTML.