### PR TITLE
Adding cacheable response plugin

### DIFF
--- a/packages/sw-cacheable-response/src/lib/plugin.js
+++ b/packages/sw-cacheable-response/src/lib/plugin.js
@@ -27,7 +27,7 @@ import assert from '../../../../lib/assert';
  *   statuses: [0, 200, 404],
  *   headers: {
  *     'Example-Header-1': 'Header-Value-1'
- *     'Example-Header-1': 'Header-Value-2'
+ *     'Example-Header-2': 'Header-Value-2'
  *   }
  * })
  *

--- a/packages/sw-lib/src/lib/sw-lib.js
+++ b/packages/sw-lib/src/lib/sw-lib.js
@@ -25,6 +25,8 @@ import {Plugin as CacheExpirationPlugin} from
   '../../../sw-cache-expiration/src/index.js';
 import {Plugin as BroadcastCacheUpdatePlugin} from
   '../../../sw-broadcast-cache-update/src/index.js';
+import {Plugin as CacheableResponsePlugin} from
+  '../../../sw-cacheable-response/src/index.js';
 import {
   CacheFirst, CacheOnly, NetworkFirst,
   NetworkOnly, StaleWhileRevalidate, RequestWrapper,
@@ -197,6 +199,13 @@ class SWLib {
    *   broadcastCacheUpdate: {
    *     channelName: 'example-channel-name'
    *   },
+   *   cacheableResponse: {
+   *     statuses: [0, 200, 404],
+   *     headers: {
+   *       'Example-Header-1': 'Header-Value-1'
+   *       'Example-Header-2': 'Header-Value-2'
+   *     }
+   *   }
    *   plugins: [
    *     // Additional Plugins
    *   ]
@@ -323,6 +332,7 @@ class SWLib {
     const pluginParamsToClass = {
       'cacheExpiration': CacheExpirationPlugin,
       'broadcastCacheUpdate': BroadcastCacheUpdatePlugin,
+      'cacheableResponse': CacheableResponsePlugin,
     };
 
     const wrapperOptions = {

--- a/packages/sw-lib/test/browser-unit/cache-revisioned-e2e.js
+++ b/packages/sw-lib/test/browser-unit/cache-revisioned-e2e.js
@@ -23,8 +23,8 @@ describe('cache-revisioned-e2e.js', function() {
   });
 
   afterEach(function() {
-    /** return window.goog.swUtils.cleanState()
-    .then(deleteIndexedDB);**/
+    return window.goog.swUtils.cleanState()
+    .then(deleteIndexedDB);
   });
 
   const testCacheEntries = (fileSet) => {

--- a/packages/sw-lib/test/browser-unit/cache-unrevisioned-e2e.js
+++ b/packages/sw-lib/test/browser-unit/cache-unrevisioned-e2e.js
@@ -23,8 +23,8 @@ describe('cache-unrevisioned-e2e.js', function() {
   });
 
   afterEach(function() {
-    /** return window.goog.swUtils.cleanState()
-    .then(deleteIndexedDB);**/
+    return window.goog.swUtils.cleanState()
+    .then(deleteIndexedDB);
   });
 
   const testCacheEntries = (fileSet) => {

--- a/packages/sw-lib/test/browser-unit/library-namespace.js
+++ b/packages/sw-lib/test/browser-unit/library-namespace.js
@@ -16,6 +16,32 @@
 describe('Test Behaviors of Loading the Script', function() {
   this.timeout(5 * 60 * 1000);
 
+  const deleteIndexedDB = () => {
+    return new Promise((resolve, reject) => {
+      // TODO: Move to constants
+      const req = indexedDB.deleteDatabase('sw-precaching');
+      req.onsuccess = function() {
+        resolve();
+      };
+      req.onerror = function() {
+        reject();
+      };
+      req.onblocked = function() {
+        console.error('Database deletion is blocked.');
+      };
+    });
+  };
+
+  beforeEach(function() {
+    return window.goog.swUtils.cleanState()
+    .then(deleteIndexedDB);
+  });
+
+  afterEach(function() {
+    return window.goog.swUtils.cleanState()
+    .then(deleteIndexedDB);
+  });
+
   it('should print an error when added to the window.', function() {
     this.timeout(2000);
 

--- a/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
+++ b/packages/sw-lib/test/browser-unit/sw-unit/caching-strategies.js
@@ -91,5 +91,21 @@ describe('Test caching strategies.', function() {
       expect(handler.requestWrapper.pluginCallbacks.cacheDidUpdate).to.exist;
       handler.requestWrapper.pluginCallbacks.cacheDidUpdate.length.should.equal(1);
     });
+
+    it(`should return a Handler when '${strategy}' is instantiated with cacheableResponse options`, function() {
+      const CACHEABLE_RESPONSE_OPTIONS = {
+        statuses: [0, 200, 404],
+        headers: {
+          'Example-Header-1': 'Header-Value-1',
+          'Example-Header-2': 'Header-Value-2',
+        },
+      };
+      const handler = goog.swlib[strategy]({
+        cacheableResponse: CACHEABLE_RESPONSE_OPTIONS,
+      });
+      expect(handler.handle).to.exist;
+      expect(handler.requestWrapper).to.exist;
+      expect(handler.requestWrapper.pluginCallbacks.cacheWillUpdate).to.exist;
+    });
   });
 });


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

This adds `sw-cachable-response` to sw-lib, just to make it friendly.

This is part of the writing up a doc on request support (https://github.com/GoogleChrome/sw-helpers/issues/78) and noticed it could be easier