### PR TITLE
Adds assertions to check the elements in an array

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -59,6 +59,38 @@ function isType(object, expectedType) {
   }
 }
 
+function isArrayOfType(object, expectedType) {
+  const parameter = Object.keys(object).pop();
+  const message = `The '${parameter}' parameter should be an array containing
+    one or more '${expectedType}' elements.`;
+
+  if (!Array.isArray(object[parameter])) {
+    throwError(message);
+  }
+
+  for (let item of object[parameter]) {
+    if (typeof item !== expectedType) {
+      throwError(message);
+    }
+  }
+}
+
+function isArrayOfClass(object, expectedClass) {
+  const parameter = Object.keys(object).pop();
+  const message = `The '${parameter}' parameter should be an array containing
+    one or more '${expectedClass.name}' instances.`;
+
+  if (!Array.isArray(object[parameter])) {
+    throwError(message);
+  }
+
+  for (let item of object[parameter]) {
+    if (!(item instanceof expectedClass)) {
+      throwError(message);
+    }
+  }
+}
+
 function isSWEnv() {
   return ('ServiceWorkerGlobalScope' in self &&
     self instanceof ServiceWorkerGlobalScope);
@@ -99,4 +131,6 @@ export default {
   isType,
   isSWEnv,
   isValue,
+  isArrayOfType,
+  isArrayOfClass,
 };

--- a/packages/sw-cache-expiration/src/lib/plugin.js
+++ b/packages/sw-cache-expiration/src/lib/plugin.js
@@ -374,7 +374,7 @@ class Plugin {
    */
   async deleteFromCacheAndIDB({cacheName, urls} = {}) {
     assert.isType({cacheName}, 'string');
-    assert.isInstance({urls}, Array);
+    assert.isArrayOfType({urls}, 'string');
 
     if (urls.length > 0) {
       const cache = await this.getCache({cacheName});

--- a/packages/sw-cacheable-response/src/lib/plugin.js
+++ b/packages/sw-cacheable-response/src/lib/plugin.js
@@ -50,7 +50,7 @@ class Plugin {
   constructor({statuses, headers} = {}) {
     assert.atLeastOne({statuses, headers});
     if (statuses !== undefined) {
-      assert.isInstance({statuses}, Array);
+      assert.isArrayOfType({statuses}, 'number');
     }
     if (headers !== undefined) {
       assert.isType({headers}, 'object');

--- a/packages/sw-routing/src/lib/navigation-route.js
+++ b/packages/sw-routing/src/lib/navigation-route.js
@@ -61,9 +61,9 @@ class NavigationRoute extends Route {
    * @param {function} input.handler The handler to manage the response.
    */
   constructor({whitelist, blacklist, handler} = {}) {
-    assert.isInstance({whitelist}, Array);
+    assert.isArrayOfClass({whitelist}, RegExp);
     if (blacklist) {
-      assert.isInstance({blacklist}, Array);
+      assert.isArrayOfClass({blacklist}, RegExp);
     } else {
       blacklist = [];
     }

--- a/packages/sw-routing/src/lib/router.js
+++ b/packages/sw-routing/src/lib/router.js
@@ -103,7 +103,7 @@ class Router {
    * @param {Array.<Route>} input.routes An array of routes to register.
    */
   registerRoutes({routes} = {}) {
-    assert.isInstance({routes}, Array);
+    assert.isArrayOfClass({routes}, Route);
 
     self.addEventListener('fetch', (event) => {
       const url = new URL(event.request.url);

--- a/packages/sw-routing/test/sw/navigation-route.js
+++ b/packages/sw-routing/test/sw/navigation-route.js
@@ -31,7 +31,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('isInstance');
+    expect(thrownError.name).to.equal('isArrayOfClass');
   });
 
   it(`should throw when NavigationRoute() is called without a valid whitelist`, function() {
@@ -42,7 +42,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('isInstance');
+    expect(thrownError.name).to.equal('isArrayOfClass');
   });
 
   it(`should throw when NavigationRoute() is called without a valid handler`, function() {
@@ -72,7 +72,7 @@ describe('Test of the NavigationRoute class', function() {
       thrownError = err;
     }
     expect(thrownError).to.exist;
-    expect(thrownError.name).to.equal('isInstance');
+    expect(thrownError.name).to.equal('isArrayOfClass');
   });
 
   it(`should not throw when NavigationRoute() is called with valid whitelist and handler parameters`, function() {

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -76,7 +76,7 @@ class RequestWrapper {
     this.pluginCallbacks = {};
 
     if (plugins) {
-      assert.isInstance({plugins}, Array);
+      assert.isArrayOfType({plugins}, 'object');
 
       plugins.forEach((plugin) => {
         for (let callbackName of pluginCallbacks) {


### PR DESCRIPTION
R: @addyosmani @gauntface

This makes `assert` a little more helpful by allowing you to check not just whether a given parameter is an array, but whether the elements in the array are of the expected type/class. Along with the nicer error message formatting that recently landing, this should help developers who, e.g., mistakenly pass in an array of strings when we expect an array of RegExp.