### PR TITLE
fixes bug #259, cloned request for every plugin

### DIFF
--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -178,7 +178,7 @@ class RequestWrapper {
    */
   async fetch({request}) {
     assert.atLeastOne({request});
-
+    const clonedRequest = request.clone();
     if (this.pluginCallbacks.requestWillFetch) {
       for (let callback of this.pluginCallbacks.requestWillFetch) {
         const returnedPromise = callback({request});
@@ -194,7 +194,9 @@ class RequestWrapper {
     } catch (err) {
       if (this.pluginCallbacks.fetchDidFail) {
         for (let callback of this.pluginCallbacks.fetchDidFail) {
-          callback({request});
+          // New clone for every plugin, so taht one plugin's read/clone
+          // does not break other plugin
+          callback({request: clonedRequest.clone()});
         }
       }
 

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -178,7 +178,8 @@ class RequestWrapper {
    */
   async fetch({request}) {
     assert.atLeastOne({request});
-    const clonedRequest = request.clone();
+    const clonedRequest = this.pluginCallbacks.fetchDidFail ?
+      request.clone() : null;
     if (this.pluginCallbacks.requestWillFetch) {
       for (let callback of this.pluginCallbacks.requestWillFetch) {
         const returnedPromise = callback({request});
@@ -194,7 +195,7 @@ class RequestWrapper {
     } catch (err) {
       if (this.pluginCallbacks.fetchDidFail) {
         for (let callback of this.pluginCallbacks.fetchDidFail) {
-          callback({request: clonedRequest});
+          callback({request: clonedRequest.clone()});
         }
       }
 

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -194,9 +194,7 @@ class RequestWrapper {
     } catch (err) {
       if (this.pluginCallbacks.fetchDidFail) {
         for (let callback of this.pluginCallbacks.fetchDidFail) {
-          // New clone for every plugin, so taht one plugin's read/clone
-          // does not break other plugin
-          callback({request: clonedRequest.clone()});
+          callback({request: clonedRequest});
         }
       }
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes #*259*

This sends a clone of request to plugins in `fetchDidFail` event

*Please ensure that `gulp lint test` passes locally prior to filing a PR!*
