### PR TITLE
Pass URL from original Request to cacheDidUpdate

### DIFF
--- a/packages/sw-cache-expiration/src/lib/plugin.js
+++ b/packages/sw-cache-expiration/src/lib/plugin.js
@@ -196,9 +196,10 @@ class Plugin {
    * @param {Object} input
    * @param {string} input.cacheName Name of the cache the responses belong to.
    * @param {Response} input.newResponse The new value in the cache.
+   * @param {string} input.url The URL for the cache entry.
    * @param {Number} [input.now] A timestamp. Defaults to the current time.
    */
-  cacheDidUpdate({cacheName, newResponse, now} = {}) {
+  cacheDidUpdate({cacheName, newResponse, url, now} = {}) {
     assert.isType({cacheName}, 'string');
     assert.isInstance({newResponse}, Response);
 
@@ -206,7 +207,7 @@ class Plugin {
       now = Date.now();
     }
 
-    this.updateTimestamp({cacheName, now, url: newResponse.url}).then(() => {
+    this.updateTimestamp({cacheName, url, now}).then(() => {
       this.expireEntries({cacheName, now});
     });
   }

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -29,9 +29,9 @@ import ErrorFactory from './error-factory';
  *   - `cacheWillUpdate({request, response})`: Called prior to writing an entry
  *   to the cache, allowing the callback to decide whether or not the cache
  *   entry should be written.
- *   - `cacheDidUpdate({cacheName, oldResponse, newResponse})`: Called whenever
- *   an entry is written to the cache, giving the callback a chance to notify
- *   clients about the update or implement cache expiration.
+ *   - `cacheDidUpdate({cacheName, oldResponse, newResponse, url})`: Called
+ *   whenever an entry is written to the cache, giving the callback a chance to
+ *   notify clients about the update or implement cache expiration.
  *   - `cacheWillMatch({cachedResponse})`: Called whenever a response is read
  *   from the cache and is about to be used, giving the callback a chance to
  *   perform validity/freshness checks.
@@ -270,7 +270,12 @@ class RequestWrapper {
         await cache.put(cacheRequest, newResponse);
 
         for (let callback of (this.pluginCallbacks.cacheDidUpdate || [])) {
-          callback({cacheName: this.cacheName, oldResponse, newResponse});
+          callback({
+            cacheName: this.cacheName,
+            oldResponse,
+            newResponse,
+            url: request.url,
+          });
         }
       });
     } else if (!cacheable && waitOnCache) {


### PR DESCRIPTION
R: @addyosmani @gauntface

I came across this when trying out cache expiration along with some opaque responses. We need to get the URL to use as the cache expiration key from the original `Request`, since an opaque `Response` doesn't even expose a URL.

This would have ideally been covered in an end-to-end test, and I've filed https://github.com/GoogleChrome/sw-helpers/issues/264 to track creating that.