### PR TITLE
Refactoring of the Plugin class in BroadcastCacheUpdate

### DIFF
--- a/packages/sw-broadcast-cache-update/demo/service-worker.js
+++ b/packages/sw-broadcast-cache-update/demo/service-worker.js
@@ -2,23 +2,20 @@
 /* global goog */
 
 importScripts(
-  '../build/routing.js',
+  '../../sw-routing/build/routing.js',
   '../../sw-runtime-caching/build/runtime-caching.js',
   '../../sw-broadcast-cache-update/build/broadcast-cache-update.js'
 );
 
 // Have the service worker take control as soon as possible.
-self.addEventListener('install', (event) => {
-  event.waitUntil(self.skipWaiting());
-});
-self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
-});
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
 
 const requestWrapper = new goog.runtimeCaching.RequestWrapper({
   cacheName: 'text-files',
   plugins: [
-    new goog.broadcastCacheUpdate.Plugin({channelName: 'cache-updates'}),
+    new goog.broadcastCacheUpdate.BroadcastCacheUpdatePlugin(
+      {channelName: 'cache-updates'}),
   ],
 });
 

--- a/packages/sw-broadcast-cache-update/src/index.js
+++ b/packages/sw-broadcast-cache-update/src/index.js
@@ -19,22 +19,23 @@
  * A helper library that uses the Broadcast Channel API to announce when
  * two Response objects differ.
  *
- * The main use of this module will be instantiating a new `Plugin` and
- * passing it to a
- * {@link  module:sw-runtime-caching.RequestWrapper|RequestWrapper},
+ * The main use of this module will be instantiating a new
+ * `BroadcastCacheUpdatePlugin` and passing it to a
+ * {@link module:sw-runtime-caching.RequestWrapper|RequestWrapper},
  * as shown in the first example below.
  *
  * You can listen for updates from your web app by adding an event listener on
- * a browser channel with the same channel name as the Plugin,
- * which 'cache-updates' in the second example below.
+ * a `BroadcastChannel` within a page, using the same channel name as
+ * what's used within the service worker, as shown in the second example below.
  *
- * @example <caption>Using the broadcastCacheUpdate.Plugin class in a
+ * @example <caption>Using the BroadcastCacheUpdatePlugin class in a
  * service worker.</caption>
  *
  * const requestWrapper = new goog.runtimeCaching.RequestWrapper({
  *   cacheName: 'text-files',
  *   plugins: [
- *     new goog.broadcastCacheUpdate.Plugin({channelName: 'cache-updates'}),
+ *     new goog.broadcastCacheUpdate.BroadcastCacheUpdatePlugin(
+ *       {channelName: 'cache-updates'})
  *   ],
  * });
  *
@@ -57,13 +58,15 @@
  * @module sw-broadcast-cache-update
  */
 
-import Plugin from './lib/plugin';
+import BroadcastCacheUpdate from './lib/broadcast-cache-update';
+import BroadcastCacheUpdatePlugin from './lib/broadcast-cache-update-plugin';
 import broadcastUpdate from './lib/broadcast-update';
 import {cacheUpdatedMessageType} from './lib/constants';
 import responsesAreSame from './lib/responses-are-same';
 
 export {
-  Plugin,
+  BroadcastCacheUpdate,
+  BroadcastCacheUpdatePlugin,
   broadcastUpdate,
   cacheUpdatedMessageType,
   responsesAreSame,

--- a/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update-plugin.js
+++ b/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update-plugin.js
@@ -1,0 +1,76 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import BroadcastCacheUpdate from './broadcast-cache-update';
+import assert from '../../../../lib/assert';
+
+/**
+ * Can be used to compare two [Responses](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+ * and uses the {@link https://developers.google.com/web/updates/2016/09/broadcastchannel|Broadcast Channel API}
+ * to notify interested parties when those responses differ.
+ *
+ * For efficiency's sake, the underlying response bodies are not compared;
+ * only specific response headers are checked.
+ *
+ * This class is meant to be automatically invoked as a plugin to a
+ * {@link module:sw-runtime-caching.RequestWrapper|RequestWrapper}, which is
+ * used by the `sw-lib` and `sw-runtime-caching` modules.
+ *
+ * If you would like to use this functionality outside of the `RequestWrapper`
+ * context, please use the `BroadcastCacheUpdate` class directly.
+ *
+ * @example <caption>Added as a "plugin" to a `RequestWrapper` to
+ * automatically dispatch messages on a cache update</caption>
+ *
+ * const requestWrapper = new goog.runtimeCaching.RequestWrapper({
+ *   cacheName: 'runtime-cache',
+ *   plugins: [
+ *     new goog.broadcastCacheUpdate.Plugin({channelName: 'cache-updates'})
+ *   ]
+ * });
+ * const route = new goog.routing.RegExpRoute({
+ *   match: ({url}) => url.domain === 'example.com',
+ *   handler: new goog.runtimeCaching.StaleWhileRevalidate({requestWrapper})
+ * });
+ *
+ * @memberof module:sw-broadcast-cache-update
+ */
+class BroadcastCacheUpdatePlugin extends BroadcastCacheUpdate {
+  /**
+   * A "lifecycle" callback that will be triggered automatically by the
+   * `sw-lib` and `sw-runtime-caching` handlers when an entry is added to a
+   * cache.
+   *
+   * @private
+   * @param {Object} input The input object to this function.
+   * @param {string} input.cacheName Name of the cache the responses belong to.
+   * @param {Response} [input.oldResponse] The previous cached value, if any.
+   * @param {Response} input.newResponse The new value in the cache.
+   */
+  cacheDidUpdate({cacheName, oldResponse, newResponse}) {
+    assert.isType({cacheName}, 'string');
+    assert.isInstance({newResponse}, Response);
+
+    if (oldResponse) {
+      this.notifyIfUpdated({
+        cacheName,
+        first: oldResponse,
+        second: newResponse,
+      });
+    }
+  }
+}
+
+export default BroadcastCacheUpdatePlugin;

--- a/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update.js
+++ b/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update.js
@@ -27,9 +27,8 @@ import {defaultHeadersToCheck, defaultSource} from './constants';
  * For efficiency's sake, the underlying response bodies are not compared;
  * only specific response headers are checked.
  *
- * This class is meant to be agnostic about the service worker environment it's
- * used in. You can include it in your own service worker code without using
- * the rest of the larger framework.
+ * This class can be used inside any service worker, without having to use any
+ * of the other modules in this repo.
  *
  * If you'd like to use this functionality but are already using `sw-lib` or
  * `sw-runtime-caching`, then please see the corresponding plugin,
@@ -47,7 +46,7 @@ import {defaultHeadersToCheck, defaultSource} from './constants';
  *   caches.open(cacheName).then((cache) => cache.match(url)),
  *   fetch(url),
  * ]).then(([first, second]) => {
- *   if (cacheResponse) {
+ *   if (first) {
  *     bcu.notifyIfUpdated({cacheName, first, second});
  *   }
  * });

--- a/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update.js
+++ b/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update.js
@@ -27,47 +27,34 @@ import {defaultHeadersToCheck, defaultSource} from './constants';
  * For efficiency's sake, the underlying response bodies are not compared;
  * only specific response headers are checked.
  *
- * @example <caption>Added as a "plugin" to a `RequestWrapper` to
- * automatically dispatch messages on a cache update</caption>
+ * This class is meant to be agnostic about the service worker environment it's
+ * used in. You can include it in your own service worker code without using
+ * the rest of the larger framework.
  *
- * const requestWrapper = new goog.runtimeCaching.RequestWrapper({
- *   cacheName: 'runtime-cache',
- *   plugins: [
- *     new goog.broadcastCacheUpdate.Plugin({channelName: 'cache-updates'})
- *   ]
+ * If you'd like to use this functionality but are already using `sw-lib` or
+ * `sw-runtime-caching`, then please see the corresponding plugin,
+ * `BroadcastCacheUpdatePlugin`, for a easy integration.
+ *
+ * @example <caption>Using BroadcastCacheUpdate when you're handling your
+ * own fetch and request logic.</caption>
+ *
+ * const url = '/path/to/file';
+ * const cacheName = 'my-runtime-cache';
+ * const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate(
+ *   {channelName: 'cache-updates'});
+ *
+ * Promise.all([
+ *   caches.open(cacheName).then((cache) => cache.match(url)),
+ *   fetch(url),
+ * ]).then(([first, second]) => {
+ *   if (cacheResponse) {
+ *     bcu.notifyIfUpdated({cacheName, first, second});
+ *   }
  * });
- * const route = new goog.routing.RegExpRoute({
- *   match: ({url}) => url.domain === 'example.com',
- *   handler: new goog.runtimeCaching.StaleWhileRevalidate({requestWrapper})
- * });
- *
- * @example <caption>Trigger a message by manually calling
- * the `notifyIfUpdated()` method.</caption>
- *
- * const cacheUpdatePlugin = new goog.broadcastCacheUpdates.Plugin({
- *   channelName: 'cache-updates'
- * });
- *
- * const url = 'https://example.com';
- * const cacheName = 'runtime-cache';
- *
- * const cache = await caches.open(cacheName);
- * const oldResponse = await cache.match(url);
- * const newResponse = await fetch(url);
- * await cache.put(url, newResponse);
- *
- * // Only check for an update if there was a previously cached response.
- * if (oldResponse) {
- *   cacheUpdatePlugin.notifyIfUpdated({
- *     first: oldResponse,
- *     second: newResponse,
- *     cacheName
- *   });
- * }
  *
  * @memberof module:sw-broadcast-cache-update
  */
-class Plugin {
+class BroadcastCacheUpdate {
   /**
    * Dispatches cache update messages when a cached response has been updated.
    * Messages will be dispatched on a broadcast channel with the name provided
@@ -106,33 +93,6 @@ class Plugin {
   }
 
   /**
-   * A "lifecycle" callback that will be triggered automatically by the
-   * goog.runtimeCaching handlers when an entry is added to a cache.
-   *
-   * Developers would normally not call this method directly; instead,
-   * [`notifyIfUpdated`](#notifyIfUpdated) provides equivalent functionality
-   * with a slightly more efficient interface.
-   *
-   * @private
-   * @param {Object} input The input object to this function.
-   * @param {string} input.cacheName Name of the cache the responses belong to.
-   * @param {Response} [input.oldResponse] The previous cached value, if any.
-   * @param {Response} input.newResponse The new value in the cache.
-   */
-  cacheDidUpdate({cacheName, oldResponse, newResponse}) {
-    assert.isType({cacheName}, 'string');
-    assert.isInstance({newResponse}, Response);
-
-    if (oldResponse) {
-      this.notifyIfUpdated({
-        cacheName,
-        first: oldResponse,
-        second: newResponse}
-      );
-    }
-  }
-
-  /**
    * An explicit method to call from your own code to trigger the comparison of
    * two [Responses](https://developer.mozilla.org/en-US/docs/Web/API/Response)
    * and fire off a notification via the
@@ -157,4 +117,4 @@ class Plugin {
   }
 }
 
-export default Plugin;
+export default BroadcastCacheUpdate;

--- a/packages/sw-broadcast-cache-update/src/lib/broadcast-update.js
+++ b/packages/sw-broadcast-cache-update/src/lib/broadcast-update.js
@@ -18,12 +18,12 @@ import {cacheUpdatedMessageType} from './constants';
 
 /**
  * You would not normally call this method directly; it's called automatically
- * by an instance of the {@link Plugin} class. It's exposed here for the
- * benefit of developers who would rather not use the full `Plugin`
- * implementation.
+ * by an instance of the {@link BroadcastCacheUpdate} class. It's exposed here
+ * for the benefit of developers who would rather not use the full
+ * `BroadcastCacheUpdate` implementation.
  *
  * Calling this will dispatch a message on the provided {@link https://developers.google.com/web/updates/2016/09/broadcastchannel|Broadcast Channel}
- * to notifiy interested subscribers about a change to a cached resource.
+ * to notify interested subscribers about a change to a cached resource.
  *
  * The message that's posted has a formation inspired by the
  * [Flux standard action](https://github.com/acdlite/flux-standard-action#introduction)

--- a/packages/sw-broadcast-cache-update/src/lib/error-factory.js
+++ b/packages/sw-broadcast-cache-update/src/lib/error-factory.js
@@ -17,7 +17,7 @@ import ErrorFactory from '../../../../lib/error-factory';
 
 const errors = {
   'channel-name-required': `The channelName parameter is required when
-    constructing a new Plugin`,
+    constructing a new BroadcastCacheUpdate instance.`,
   'responses-are-same-parameters-required': `The first, second, and
     headersToCheck parameters must be valid when calling responsesAreSame()`,
 };

--- a/packages/sw-broadcast-cache-update/test/browser/register-unit-tests.js
+++ b/packages/sw-broadcast-cache-update/test/browser/register-unit-tests.js
@@ -1,7 +1,8 @@
 describe('Service Worker Unit Test Registration', function() {
   const pathPrefix = '../sw/';
   const swUnitTests = [
-    'plugin.js',
+    'broadcast-cache-update.js',
+    'broadcast-cache-update-plugin.js',
     'broadcast-update.js',
     'namespace.js',
     'responses-are-same.js',

--- a/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update-plugin.js
+++ b/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update-plugin.js
@@ -1,0 +1,46 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('Test of the BroadcastCacheUpdatePlugin class', function() {
+  const channelName = 'test-channel';
+  const cacheName = 'test-cache';
+  const oldResponse = new Response();
+  const newResponse = new Response();
+  const bcuPlugin = new goog.broadcastCacheUpdate.BroadcastCacheUpdatePlugin({channelName});
+
+  it(`should throw when cacheDidUpdate is called and cacheName is missing`, function() {
+    let thrownError = null;
+    try {
+      bcuPlugin.cacheDidUpdate({oldResponse, newResponse});
+    } catch(err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('isType');
+  });
+
+  it(`should throw when cacheDidUpdate is called and newResponse is missing`, function() {
+    let thrownError = null;
+    try {
+      bcuPlugin.cacheDidUpdate({cacheName, oldResponse});
+    } catch(err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('isInstance');
+  });
+
+  it(`should throw not throw when cacheDidUpdate is called with valid parameters`, function() {
+    bcuPlugin.cacheDidUpdate({cacheName, oldResponse, newResponse});
+  });
+});

--- a/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update.js
+++ b/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update.js
@@ -11,15 +11,15 @@ mocha.setup({
   reporter: null,
 });
 
-describe('Test of the Plugin class', function() {
+describe('Test of the BroadcastCacheUpdate class', function() {
   const channelName = 'test-channel';
   const headersToCheck = ['one', 'two'];
   const source = 'test-source';
 
-  it(`should throw when Plugin() is called without any parameters`, function() {
+  it(`should throw when BroadcastCacheUpdate() is called without any parameters`, function() {
     let thrownError = null;
     try {
-      new goog.broadcastCacheUpdate.Plugin();
+      new goog.broadcastCacheUpdate.BroadcastCacheUpdate();
     } catch(err) {
       thrownError = err;
     }
@@ -28,38 +28,38 @@ describe('Test of the Plugin class', function() {
   });
 
   it(`should use the channelName from the constructor`, function() {
-    const plugin = new goog.broadcastCacheUpdate.Plugin({channelName});
-    expect(plugin.channelName).to.equal(channelName);
+    const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate({channelName});
+    expect(bcu.channelName).to.equal(channelName);
   });
 
   it(`should use the headersToCheck from the constructor`, function() {
-    const plugin = new goog.broadcastCacheUpdate.Plugin({channelName, headersToCheck});
-    expect(plugin.headersToCheck).to.equal(headersToCheck);
+    const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate({channelName, headersToCheck});
+    expect(bcu.headersToCheck).to.equal(headersToCheck);
   });
 
   it(`should use a default value for headersToCheck when one isn't provided`, function() {
-    const plugin = new goog.broadcastCacheUpdate.Plugin({channelName});
-    expect(plugin.headersToCheck).to.not.be.empty;
+    const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate({channelName});
+    expect(bcu.headersToCheck).to.not.be.empty;
   });
 
   it(`should use the source from the constructor`, function() {
-    const plugin = new goog.broadcastCacheUpdate.Plugin({channelName, source});
-    expect(plugin.source).to.equal(source);
+    const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate({channelName, source});
+    expect(bcu.source).to.equal(source);
   });
 
   it(`should use a default value for source when one isn't provided`, function() {
-    const plugin = new goog.broadcastCacheUpdate.Plugin({channelName});
-    expect(plugin.source).to.not.be.empty;
+    const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate({channelName});
+    expect(bcu.source).to.not.be.empty;
   });
 
   it(`should create and reuse a BroadcastChannel based on channelName`, function() {
-    const plugin = new goog.broadcastCacheUpdate.Plugin({channelName});
-    const broadcastChannel = plugin.channel;
+    const bcu = new goog.broadcastCacheUpdate.BroadcastCacheUpdate({channelName});
+    const broadcastChannel = bcu.channel;
     expect(broadcastChannel).to.be.instanceof(BroadcastChannel);
-    // plugin.channel is a getter that create a BroadcastChannel the first
+    // bcu.channel is a getter that create a BroadcastChannel the first
     // time it's called, and this test confirms that it returns the same
     // BroadcastChannel object when called twice.
-    expect(broadcastChannel).to.eql(plugin.channel);
+    expect(broadcastChannel).to.eql(bcu.channel);
     expect(broadcastChannel.name).to.equal(channelName);
   });
 });

--- a/packages/sw-broadcast-cache-update/test/sw/namespace.js
+++ b/packages/sw-broadcast-cache-update/test/sw/namespace.js
@@ -12,7 +12,8 @@ mocha.setup({
 });
 
 const exportedSymbols = [
-  'Plugin',
+  'BroadcastCacheUpdate',
+  'BroadcastCacheUpdatePlugin',
   'broadcastUpdate',
   'cacheUpdatedMessageType',
   'responsesAreSame',

--- a/packages/sw-lib/src/lib/sw-lib.js
+++ b/packages/sw-lib/src/lib/sw-lib.js
@@ -23,7 +23,7 @@ import {
 import {Route} from '../../../sw-routing/src/index.js';
 import {Plugin as CacheExpirationPlugin} from
   '../../../sw-cache-expiration/src/index.js';
-import {Plugin as BroadcastCacheUpdatePlugin} from
+import {BroadcastCacheUpdatePlugin} from
   '../../../sw-broadcast-cache-update/src/index.js';
 import {Plugin as CacheableResponsePlugin} from
   '../../../sw-cacheable-response/src/index.js';


### PR DESCRIPTION
R: @addyosmani @gauntface

It ended up touching many more files/docs/tests than I thought it would, so I've limited this PR to just handle it for the `BroadcastCacheUpdate` class. I'll do follow-up PRs for the other libraries, and use #282 to track all of them.