### PR TITLE
Adds a networkTimeoutSeconds option to the NetworkFirst strategy.

### DIFF
--- a/packages/sw-runtime-caching/demo/service-worker.js
+++ b/packages/sw-runtime-caching/demo/service-worker.js
@@ -8,17 +8,14 @@ importScripts(
 );
 
 // Have the service worker take control as soon as possible.
-self.addEventListener('install', (event) => {
-  event.waitUntil(self.skipWaiting());
-});
-self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
-});
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
 
 const requestWrapper = new goog.runtimeCaching.RequestWrapper({
   cacheName: 'text-files',
   plugins: [
-    new goog.broadcastCacheUpdate.Plugin({channelName: 'cache-updates'}),
+    new goog.broadcastCacheUpdate.BroadcastCacheUpdatePlugin(
+      {channelName: 'cache-updates'}),
   ],
 });
 
@@ -29,4 +26,5 @@ const route = new goog.routing.RegExpRoute({
 
 const router = new goog.routing.Router();
 router.registerRoute({route});
-router.setDefaultHandler({handler: new goog.runtimeCaching.NetworkFirst()});
+router.setDefaultHandler({handler: new goog.runtimeCaching.NetworkFirst(
+  {networkTimeoutSeconds: 10})});


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #246

This is code fundamentally the same as [`sw-toolbox`'s implementation](https://github.com/GoogleChrome/sw-toolbox/blob/master/lib/strategies/networkFirst.js#L35).

I feel bad about not having a test for the new functionality, but then I feel worse about not having written tests for any of the `sw-runtime-caching` classes yet. So it balances out?

(But I will write tests for them in a future PR.)