### PR TITLE
Adds registerNavigationRoute to sw-lib

### DIFF
--- a/packages/sw-lib/src/lib/error-factory.js
+++ b/packages/sw-lib/src/lib/error-factory.js
@@ -24,6 +24,8 @@ const errors = {
   'bad-revisioned-cache-list': `The 'cacheRevisionedAssets()' method expects` +
     `an array of revisioned urls like so: ['/example/hello.1234.txt', ` +
     `{path: 'hello.txt', revision: '1234'}]`,
+  'navigation-route-url-string': `The registerNavigationRoute() method ` +
+    `expects a URL string as its first parameter.`,
 };
 
 export default new ErrorFactory(errors);

--- a/packages/sw-lib/src/lib/router.js
+++ b/packages/sw-lib/src/lib/router.js
@@ -118,7 +118,7 @@ class Router extends SWRoutingRouter {
       throw ErrorFactory.createError('navigation-route-url-string');
     }
 
-    this._router.registerRoute({route: new NavigationRoute({
+    super.registerRoute({route: new NavigationRoute({
       handler: () => caches.match(url),
       whitelist: options.whitelist || [/./],
       blacklist: options.blacklist || [],

--- a/packages/sw-lib/src/lib/router.js
+++ b/packages/sw-lib/src/lib/router.js
@@ -15,8 +15,13 @@
 
 /* eslint-env browser, serviceworker */
 
-import {Router as SWRoutingRouter, ExpressRoute, RegExpRoute, Route}
-  from '../../../sw-routing/src/index.js';
+import {
+  Router as SWRoutingRouter,
+  ExpressRoute,
+  RegExpRoute,
+  Route,
+  NavigationRoute
+} from '../../../sw-routing/src/index.js';
 import ErrorFactory from './error-factory.js';
 
 /**
@@ -87,6 +92,37 @@ class Router extends SWRoutingRouter {
     } else {
       throw ErrorFactory.createError('unsupported-route-type');
     }
+  }
+
+  /**
+   * A shortcut used to register a {@link module:sw-routing.NavigationRoute}
+   * instance that will respond to navigation requests using a cache entry for
+   * `url`.
+   *
+   * This is useful when following the [App Shell pattern](https://developers.google.com/web/fundamentals/architecture/app-shell#example-html-for-appshell),
+   * in which the previously cached shell is returned for all navigations.
+   *
+   * The `url` value should correspond to an entry that's already in the cache,
+   * perhaps a URL that is managed by
+   * {@link module:sw-lib.SWLib#cacheRevisionedAssets}. Using a URL that isn't
+   * already cached will lead to failed navigations.
+   *
+   * @param {String} url The URL of the already cached HTML resource.
+   * @param {Object} [options]
+   * @param {Array<RegExp>} [options.blacklist] Defaults to an empty blacklist.
+   * @param {Array<RegExp>} [options.whitelist] Defaults to `[/./]`, which will
+   *        match all request URLs.
+   */
+  registerNavigationRoute(url, options = {}) {
+    if (typeof url !== 'string') {
+      throw ErrorFactory.createError('navigation-route-url-string');
+    }
+
+    this._router.registerRoute({route: new NavigationRoute({
+      handler: () => caches.match(url),
+      whitelist: options.whitelist || [/./],
+      blacklist: options.blacklist || [],
+    })});
   }
 }
 

--- a/packages/sw-lib/src/lib/router.js
+++ b/packages/sw-lib/src/lib/router.js
@@ -20,7 +20,7 @@ import {
   ExpressRoute,
   RegExpRoute,
   Route,
-  NavigationRoute
+  NavigationRoute,
 } from '../../../sw-routing/src/index.js';
 import ErrorFactory from './error-factory.js';
 

--- a/packages/sw-lib/test/browser/index.html
+++ b/packages/sw-lib/test/browser/index.html
@@ -62,6 +62,7 @@
     <script src="library-namespace.js"></script>
     <script src="cache-revisioned-e2e.js"></script>
     <script src="cache-unrevisioned-e2e.js"></script>
+    <script src="navigation-route-e2e.js"></script>
 
     <script>
       (function() {

--- a/packages/sw-lib/test/browser/navigation-route-e2e.js
+++ b/packages/sw-lib/test/browser/navigation-route-e2e.js
@@ -1,0 +1,24 @@
+/* global goog, expect */
+
+describe('End to End Test of registerNavigationRoute()', function() {
+  // This uses {once: true} to ensure that each load event handler is only called once.
+  // It also modifies the iframe.src instead of using fetch(), since you can't use fetch()
+  // to make a request with mode === 'navigate'.
+  it(`should serve the App Shell content based on the whitelist/blacklist`, function(callback) {
+    goog.swUtils.activateSW('../static/sw/navigation-route.js')
+      .then((iframe) => {
+        iframe.addEventListener('load', () => {
+          expect(iframe.contentWindow.document.body.innerText).to.equal('navigation');
+
+          iframe.addEventListener('load', () => {
+            expect(iframe.contentWindow.document.body.innerText).not.to.equal('navigation');
+            callback();
+          }, {once: true});
+
+          iframe.src = iframe.src + '/blacklisted';
+        }, {once: true});
+
+        iframe.src = iframe.src + '/navigation';
+      });
+  });
+});

--- a/packages/sw-lib/test/static/sw/navigation-route.js
+++ b/packages/sw-lib/test/static/sw/navigation-route.js
@@ -1,0 +1,19 @@
+/* global goog */
+
+importScripts('/packages/sw-lib/build/sw-lib.min.js');
+
+const SHELL_URL = '/shell';
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open('navigation-route-e2e')
+      .then((cache) => cache.put(SHELL_URL, new Response('navigation')))
+  );
+});
+
+self.addEventListener('activate', () => self.clients.claim());
+
+goog.swlib.router.registerNavigationRoute(SHELL_URL, {
+  blacklist: [/blacklisted/],
+});

--- a/packages/sw-lib/test/sw/router.js
+++ b/packages/sw-lib/test/sw/router.js
@@ -135,4 +135,16 @@ describe('Test swlib.router', function() {
       self.dispatchEvent(fetchEvent);
     });
   });
+
+  it(`should throw when registerNavigationRoute() isn't passed a URL`, function() {
+    let thrownError = null;
+    try {
+      goog.swlib.router.registerNavigationRoute();
+    } catch (err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('navigation-route-url-string');
+  });
 });


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #169

Adds support for `swLib.router.registerNavigationRoute('/app-shell-url');` and associated tests.