### PR TITLE
Removing unnessecary requires for drivers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "serve": "npm-publish-scripts serve",
     "publish-gh-pages": "npm-publish-scripts publish-docs",
-    "publish-release": "gulp build && gulp test && lerna publish"
+    "publish-release": "lerna bootstrap --concurrency 1 && gulp test && lerna publish --concurrency 1"
   },
   "version": "0.0.0",
   "description": "Top-level scripts and dependencies for the sw-helpers monorepo. Not meant to be published to npm.",
@@ -59,7 +59,6 @@
     "minimist": "^1.2.0",
     "mockdate": "^2.0.1",
     "npm-publish-scripts": "^4.1.5",
-    "operadriver": "^1.0.0",
     "parse-appcache-manifest": "^0.2.0",
     "path-to-regexp": "^1.6.0",
     "promisify-node": "^0.4.0",

--- a/packages/sw-appcache-behavior/test/automated-suite.js
+++ b/packages/sw-appcache-behavior/test/automated-suite.js
@@ -33,7 +33,6 @@ const testServer = require('../../../utils/test-server');
 // Ensure the selenium drivers are added Node scripts path.
 require('geckodriver');
 require('chromedriver');
-require('operadriver');
 
 const fsePromise = promisify('fs-extra');
 
@@ -274,21 +273,9 @@ const configureTestSuite = function(browser) {
 };
 
 seleniumAssistant.getLocalBrowsers().forEach(function(browser) {
-  // Blackliist browsers here if needed.
-  if (browser.getId() === 'opera' && browser.getVersionNumber() === 41) {
-    console.warn('Skipping Opera version 41 due to operadriver error.');
-    return;
-  }
-
   switch (browser.getId()) {
     case 'chrome':
     case 'firefox':
-    case 'opera':
-      if (browser.getId() === 'opera' &&
-        browser.getVersionNumber() <= 43) {
-        console.log(`Skipping Opera <= 43 due to driver issues.`);
-        return;
-      }
       configureTestSuite(browser);
       break;
     default:

--- a/packages/sw-background-sync-queue/test/automated-suite.js
+++ b/packages/sw-background-sync-queue/test/automated-suite.js
@@ -26,11 +26,6 @@ const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
 const testServer = new swTestingHelpers.TestServer();
 
-// Ensure the selenium drivers are added Node scripts path.
-require('geckodriver');
-require('chromedriver');
-require('operadriver');
-
 const TIMEOUT = 10 * 1000;
 const RETRIES = 3;
 
@@ -89,18 +84,11 @@ const configureTestSuite = function(browser) {
 };
 
 (function(browser) {
-  // Blacklist browsers here if needed.
-  if (browser.getId() === 'opera' && browser.getVersionNumber() === 41) {
-    console.warn('Skipping Opera version 41 due to operadriver error.');
-    return;
-  }
-
   switch (browser.getId()) {
     case 'chrome':
+    case 'firefox':
       configureTestSuite(browser);
       break;
-    case 'firefox':
-    case 'opera':
     default:
       console.warn(`Skipping ${browser.getPrettyName()}.`);
       break;

--- a/packages/sw-broadcast-cache-update/test/automated-test-suite.js
+++ b/packages/sw-broadcast-cache-update/test/automated-test-suite.js
@@ -17,10 +17,6 @@ const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
 const testServer = require('../../../utils/test-server.js');
 
-require('chromedriver');
-require('operadriver');
-require('geckodriver');
-
 const RETRIES = 3;
 const TIMEOUT = 10 * 1000;
 const packageName = 'sw-broadcast-cache-update';
@@ -62,12 +58,6 @@ describe(`${packageName} Browser Tests`, function() {
 
   seleniumAssistant.getLocalBrowsers().forEach((browser) => {
     switch(browser.getId()) {
-      case 'opera':
-        if (browser.getVersionNumber() <= 43) {
-          console.log(`Skipping Opera <= 43 due to driver issues.`);
-          return;
-        }
-      // fall through
       case 'chrome':
       case 'firefox':
         setupTestSuite(browser);

--- a/packages/sw-cache-expiration/test/automated-test-suite.js
+++ b/packages/sw-cache-expiration/test/automated-test-suite.js
@@ -17,10 +17,6 @@ const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
 const testServer = require('../../../utils/test-server.js');
 
-require('chromedriver');
-require('operadriver');
-require('geckodriver');
-
 const RETRIES = 3;
 const TIMEOUT = 10 * 1000;
 const packageName = 'sw-cache-expiration';
@@ -62,12 +58,6 @@ describe(`${packageName} Browser Tests`, function() {
 
   seleniumAssistant.getLocalBrowsers().forEach((browser) => {
     switch(browser.getId()) {
-      case 'opera':
-        if (browser.getVersionNumber() <= 43) {
-          console.log(`Skipping Opera <= 43 due to driver issues.`);
-          return;
-        }
-      // fall through
       case 'chrome':
       case 'firefox':
         setupTestSuite(browser);

--- a/packages/sw-lib/test/automated-test-suite.js
+++ b/packages/sw-lib/test/automated-test-suite.js
@@ -17,10 +17,6 @@ const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
 const testServer = require('../../../utils/test-server.js');
 
-require('chromedriver');
-require('operadriver');
-require('geckodriver');
-
 const RETRIES = 3;
 const TIMEOUT = 10 * 1000;
 

--- a/packages/sw-offline-google-analytics/test/automated-suite.js
+++ b/packages/sw-offline-google-analytics/test/automated-suite.js
@@ -26,11 +26,6 @@ const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
 const testServer = require('../../../utils/test-server');
 
-// Ensure the selenium drivers are added Node scripts path.
-require('geckodriver');
-require('chromedriver');
-require('operadriver');
-
 const TIMEOUT = 10 * 1000;
 const RETRIES = 3;
 
@@ -89,21 +84,9 @@ describe(`sw-offline-google-analytics Test Suite`, function() {
   };
 
   seleniumAssistant.getLocalBrowsers().forEach(function(browser) {
-    // Blackliist browsers here if needed.
-    if (browser.getId() === 'opera' && browser.getVersionNumber() === 41) {
-      console.warn('Skipping Opera version 41 due to operadriver error.');
-      return;
-    }
-
     switch (browser.getId()) {
       case 'chrome':
       case 'firefox':
-      case 'opera':
-        if (browser.getId() === 'opera' &&
-          browser.getVersionNumber() <= 43) {
-          console.log(`Skipping Opera <= 43 due to driver issues.`);
-          return;
-        }
         configureTestSuite(browser);
         break;
       default:

--- a/packages/sw-routing/test/automated-test-suite.js
+++ b/packages/sw-routing/test/automated-test-suite.js
@@ -17,10 +17,6 @@ const seleniumAssistant = require('selenium-assistant');
 const swTestingHelpers = require('sw-testing-helpers');
 const testServer = require('../../../utils/test-server.js');
 
-require('chromedriver');
-require('operadriver');
-require('geckodriver');
-
 const RETRIES = 3;
 const TIMEOUT = 10 * 1000;
 
@@ -61,12 +57,6 @@ describe(`sw-routing Browser Tests`, function() {
 
   seleniumAssistant.getLocalBrowsers().forEach((browser) => {
     switch(browser.getId()) {
-      case 'opera':
-        if (browser.getVersionNumber() <= 43) {
-          console.log(`Skipping Opera <= 43 due to driver issues.`);
-          return;
-        }
-        // fall through
       case 'chrome':
       case 'firefox':
         setupTestSuite(browser);


### PR DESCRIPTION
R: @jeffposnick @addyosmani 

Non-important change - but requires are handled by selenium-assistant behind the scenes so we don't need to have them in our files.

Removed Opera because it's nothing but trouble (Driver + Browser seem to be not working together).
