### PR TITLE
Adds a log message when a response isn't cached.

### DIFF
--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -4,7 +4,7 @@
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
 */
 
 import assert from '../../../../lib/assert';
+import logHelper from '../../../../lib/log-helper.js';
 import {pluginCallbacks, defaultCacheName} from './constants';
 import ErrorFactory from './error-factory';
 
@@ -278,10 +279,17 @@ class RequestWrapper {
           });
         }
       });
-    } else if (!cacheable && waitOnCache) {
-      // If the developer request to wait on the cache but the response
-      // isn't cacheable, throw an error.
-      throw ErrorFactory.createError('invalid-reponse-for-caching');
+    } else if (!cacheable) {
+      logHelper.debug(`[RequestWrapper] The response for ${request.url}, with 
+        a status of ${response.status}, wasn't cached. By default, only
+        responses with a status of 200 are cached. You can configure the
+        cacheableResponse plugin to change this default.`.replace(/\s+/g, ' '));
+
+      if (waitOnCache) {
+        // If the developer request to wait on the cache but the response
+        // isn't cacheable, throw an error.
+        throw ErrorFactory.createError('invalid-reponse-for-caching');
+      }
     }
 
     // Only conditionally await the caching completion, giving developers the

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -4,7 +4,7 @@
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
- http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #304

This leads to log messages along the lines of:

`[RequestWrapper] The response for https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.js, with a status of 0, wasn't cached. By default, only responses with a status of 200 are cached. You can configure the cacheableResponse plugin to change this default.`