### PR TITLE
Use a single fetch handler per Router

### DIFF
--- a/packages/sw-routing/src/lib/router.js
+++ b/packages/sw-routing/src/lib/router.js
@@ -50,6 +50,92 @@ import logHelper from '../../../../lib/log-helper.js';
  */
 class Router {
   /**
+   * Start with an empty array of routes, and set up the fetch handler.
+   */
+  constructor() {
+    this._routes = [];
+
+    self.addEventListener('fetch', (event) => {
+      const url = new URL(event.request.url);
+      if (!url.protocol.startsWith('http')) {
+        logHelper.log({
+          that: this,
+          message: 'URL does not start with HTTP and so not passing ' +
+            'through the router.',
+          data: {
+            request: event.request,
+          },
+        });
+        return;
+      }
+
+      let responsePromise;
+      let matchingRoute;
+      for (let route of this._routes) {
+        if (route.method !== event.request.method) {
+          continue;
+        }
+
+        const matchResult = route.match({url, event});
+        if (matchResult) {
+          matchingRoute = route;
+
+          logHelper.log({
+            that: this,
+            message: 'The router is founda matching route.',
+            data: {
+              route: matchingRoute,
+              request: event.request,
+            },
+          });
+
+          let params = matchResult;
+
+          if (Array.isArray(params) && params.length === 0) {
+            // Instead of passing an empty array in as params, use undefined.
+            params = undefined;
+          } else if (params.constructor === Object &&
+                     Object.keys(params).length === 0) {
+            // Instead of passing an empty object in as params, use undefined.
+            params = undefined;
+          }
+
+          matchingRoute = route;
+          responsePromise = route.handler.handle({url, event, params});
+          break;
+        }
+      }
+
+      if (!responsePromise && this.defaultHandler) {
+        responsePromise = this.defaultHandler.handle({url, event});
+      }
+
+      if (responsePromise && this.catchHandler) {
+        responsePromise = responsePromise.catch((error) => {
+          return this.catchHandler.handle({url, event, error});
+        });
+      }
+
+      if (responsePromise) {
+        event.respondWith(responsePromise
+          .then((response) => {
+            logHelper.debug({
+              that: this,
+              message: 'The router is managing a route with a response.',
+              data: {
+                route: matchingRoute,
+                request: event.request,
+                response: response,
+              },
+            });
+
+            return response;
+          }));
+      }
+    });
+  }
+
+  /**
    * An optional default handler will have its handle method called when a
    * request doesn't have a matching route.
    *
@@ -105,85 +191,8 @@ class Router {
    */
   registerRoutes({routes} = {}) {
     assert.isArrayOfClass({routes}, Route);
-
-    self.addEventListener('fetch', (event) => {
-      const url = new URL(event.request.url);
-      if (!url.protocol.startsWith('http')) {
-        logHelper.log({
-          that: this,
-          message: 'URL does not start with HTTP and so not parsing ' +
-            'through the router.',
-          data: {
-            request: event.request,
-          },
-        });
-        return;
-      }
-
-      let responsePromise;
-      let matchingRoute;
-      for (let route of (routes || [])) {
-        if (route.method !== event.request.method) {
-          continue;
-        }
-
-        const matchResult = route.match({url, event});
-        if (matchResult) {
-          matchingRoute = route;
-
-          logHelper.log({
-            that: this,
-            message: 'The router is founda matching route.',
-            data: {
-              route: matchingRoute,
-              request: event.request,
-            },
-          });
-
-          let params = matchResult;
-
-          if (Array.isArray(params) && params.length === 0) {
-            // Instead of passing an empty array in as params, use undefined.
-            params = undefined;
-          } else if (params.constructor === Object &&
-                     Object.keys(params).length === 0) {
-            // Instead of passing an empty object in as params, use undefined.
-            params = undefined;
-          }
-
-          matchingRoute = route;
-          responsePromise = route.handler.handle({url, event, params});
-          break;
-        }
-      }
-
-      if (!responsePromise && this.defaultHandler) {
-        responsePromise = this.defaultHandler.handle({url, event});
-      }
-
-      if (responsePromise && this.catchHandler) {
-        responsePromise = responsePromise.catch((error) => {
-          return this.catchHandler.handle({url, event, error});
-        });
-      }
-
-      if (responsePromise) {
-        event.respondWith(responsePromise
-        .then((response) => {
-          logHelper.debug({
-            that: this,
-            message: 'The router is managing a route with a response.',
-            data: {
-              route: matchingRoute,
-              request: event.request,
-              response: response,
-            },
-          });
-
-          return response;
-        }));
-      }
-    });
+    // Give precedence to the newly registered routes by listing them first.
+    this._routes = routes.concat(this._routes);
   }
 
   /**

--- a/packages/sw-routing/src/lib/router.js
+++ b/packages/sw-routing/src/lib/router.js
@@ -53,6 +53,8 @@ class Router {
    * Start with an empty array of routes, and set up the fetch handler.
    */
   constructor() {
+    // _routes will contain a mapping of HTTP method name ('GET', etc.) to an
+    // array of all the corresponding Route instances that are registered.
     this._routes = new Map();
 
     self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
R: @addyosmani @gauntface

The diff is pretty busy, but this is basically just shifting the `fetch` handler into the `Router` constructor, and storing the list of routes in a private member variable.

Fixes #354