### PR TITLE
Refactor the CacheableResponsePlugin to a separate class

### DIFF
--- a/packages/sw-cacheable-response/src/index.js
+++ b/packages/sw-cacheable-response/src/index.js
@@ -43,6 +43,10 @@
  * @module sw-cacheable-response
  */
 
-import Plugin from './lib/plugin';
+import CacheableResponse from './lib/cacheable-response';
+import CacheableResponsePlugin from './lib/cacheable-response-plugin';
 
-export {Plugin};
+export {
+  CacheableResponse,
+  CacheableResponsePlugin,
+};

--- a/packages/sw-cacheable-response/src/lib/cacheable-response-plugin.js
+++ b/packages/sw-cacheable-response/src/lib/cacheable-response-plugin.js
@@ -1,0 +1,59 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import CacheableResponse from './cacheable-response';
+
+/**
+ * Use this plugin to cache responses with certain HTTP status codes or
+ * header values.
+ *
+ * Defining both status codes and headers will cache requests with a matching
+ * status code and a matching header.
+ *
+ * This class is meant to be automatically invoked as a plugin to a
+ * {@link module:sw-runtime-caching.RequestWrapper|RequestWrapper}, which is
+ * used by the `sw-lib` and `sw-runtime-caching` modules.
+ *
+ * If you would like to use this functionality outside of the `RequestWrapper`
+ * context, please use the `CacheableResponse` class directly.
+ *
+ * @example
+ * new goog.cacheableResponse.CacheableResponsePlugin({
+ *   statuses: [0, 200, 404],
+ *   headers: {
+ *     'Example-Header-1': 'Header-Value-1'
+ *     'Example-Header-2': 'Header-Value-2'
+ *   }
+ * });
+ *
+ * @memberof module:sw-cacheable-response
+ */
+class CacheableResponsePlugin extends CacheableResponse {
+  /**
+   * A "lifecycle" callback that will be triggered automatically by the
+   * `goog.runtimeCaching` handlers prior to an entry being added to a cache.
+   *
+   * @private
+   * @param {Object} input
+   * @param {Response} input.response The response that might be cached.
+   * @return {boolean} `true` if the `Response` is cacheable, based on the
+   *          configuration of this object, and `false` otherwise.
+   */
+  cacheWillUpdate({response} = {}) {
+    return this.isResponseCacheable({response});
+  }
+}
+
+export default CacheableResponsePlugin;

--- a/packages/sw-cacheable-response/src/lib/cacheable-response.js
+++ b/packages/sw-cacheable-response/src/lib/cacheable-response.js
@@ -14,6 +14,7 @@
 */
 
 import assert from '../../../../lib/assert';
+import logHelper from '../../../../lib/log-helper.js';
 
 /**
  * Use this plugin to cache responses with certain HTTP status codes or
@@ -81,6 +82,22 @@ class CacheableResponse {
     if (this.headers && cacheable) {
       cacheable = Object.keys(this.headers).some((headerName) => {
         return response.headers.get(headerName) === this.headers[headerName];
+      });
+    }
+
+    if (!cacheable) {
+      const data = {response};
+      if (this.statuses) {
+        data['valid-status-codes'] = JSON.stringify(this.statuses);
+      }
+      if (this.headers) {
+        data['valid-headers'] = JSON.stringify(this.headers);
+      }
+
+      logHelper.debug({
+        message: `The response does not meet the criteria for being added ` +
+          `to the cache.`,
+        data,
       });
     }
 

--- a/packages/sw-cacheable-response/src/lib/cacheable-response.js
+++ b/packages/sw-cacheable-response/src/lib/cacheable-response.js
@@ -23,7 +23,7 @@ import assert from '../../../../lib/assert';
  * status code and a matching header.
  *
  * @example
- * new goog.cacheableResponse.Plugin({
+ * new goog.cacheableResponse.CacheableResponse({
  *   statuses: [0, 200, 404],
  *   headers: {
  *     'Example-Header-1': 'Header-Value-1'
@@ -33,7 +33,7 @@ import assert from '../../../../lib/assert';
  *
  * @memberof module:sw-cacheable-response
  */
-class Plugin {
+class CacheableResponse {
   /**
    * Creates a new `Plugin` instance, which stores configuration and logic
    * to determine whether a `Response` object is cacheable or not.
@@ -61,30 +61,12 @@ class Plugin {
   }
 
   /**
-   * A "lifecycle" callback that will be triggered automatically by the
-   * `goog.runtimeCaching` handlers prior to an entry being added to a cache.
-   *
-   * Developers would normally not call this method directly; instead,
-   * [`isResponseCacheable`](#isResponseCacheable) provides equivalent behavior
-   * when used outside of `goog.runtimeCaching`.
-   *
-   * @private
-   * @param {Object} input
-   * @param {Response} input.newResponse The response that might be cached.
-   * @return {boolean} `true` if the `Response` is cacheable, based on the
-   *          configuration of this object, and `false` otherwise.
-   */
-  cacheWillUpdate({response} = {}) {
-    return this.isResponseCacheable({response});
-  }
-
-  /**
    * Checks a response to see whether it's cacheable or not, based on the
    * configuration of this object.
    *
    * @private
    * @param {Object} input
-   * @param {Response} input.newResponse The response that might be cached.
+   * @param {Response} input.response The response that might be cached.
    * @return {boolean} `true` if the `Response` is cacheable, based on the
    *          configuration of this object, and `false` otherwise.
    */
@@ -106,4 +88,4 @@ class Plugin {
   }
 }
 
-export default Plugin;
+export default CacheableResponse;

--- a/packages/sw-cacheable-response/test/.eslintrc
+++ b/packages/sw-cacheable-response/test/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "rules": {
+    "no-console": 0,
+    "max-len": 0,
+    "no-invalid-this": 0,
+    "require-jsdoc": 0
+  },
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "goog": true,
+    "expect": true
+  }
+}

--- a/packages/sw-cacheable-response/test/automated-test-suite.js
+++ b/packages/sw-cacheable-response/test/automated-test-suite.js
@@ -1,0 +1,69 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+const seleniumAssistant = require('selenium-assistant');
+const swTestingHelpers = require('sw-testing-helpers');
+const testServer = require('../../../utils/test-server.js');
+
+const RETRIES = 3;
+const TIMEOUT = 10 * 1000;
+const packageName = 'sw-cacheable-response';
+
+describe(`${packageName} Browser Tests`, function() {
+  this.retries(RETRIES);
+  this.timeout(TIMEOUT);
+
+  let globalDriverBrowser;
+  let testHarnessUrl;
+
+  // Set up the web server before running any tests in this suite.
+  before(() => testServer.start('.').then((portNumber) => {
+    testHarnessUrl = `http://localhost:${portNumber}/__test/mocha/${packageName}`;
+  }));
+
+  // Kill the web server once all tests are complete.
+  after(() => testServer.stop());
+
+  afterEach(() => seleniumAssistant.killWebDriver(globalDriverBrowser)
+    .then(() => globalDriverBrowser = null));
+
+  const setupTestSuite = (assistantDriver) => {
+    it(`should pass all tests in ${assistantDriver.getPrettyName()}`, () => {
+      return assistantDriver.getSeleniumDriver()
+        .then((driver) => globalDriverBrowser = driver)
+        .then(() => swTestingHelpers.mochaUtils.startWebDriverMochaTests(
+          assistantDriver.getPrettyName(),
+          globalDriverBrowser,
+          testHarnessUrl
+        )).then((testResults) => {
+          console.log(swTestingHelpers.mochaUtils.prettyPrintResults(testResults));
+          if (testResults.failed.length > 0) {
+            throw new Error('Some of the browser tests failed.');
+          }
+        });
+    });
+  };
+
+  seleniumAssistant.getLocalBrowsers().forEach((browser) => {
+    switch(browser.getId()) {
+      case 'chrome':
+      case 'firefox':
+        setupTestSuite(browser);
+        break;
+      default:
+        console.log(`Skipping tests for ${browser.getId()}.`);
+    }
+  });
+});

--- a/packages/sw-cacheable-response/test/automated-test-suite.js
+++ b/packages/sw-cacheable-response/test/automated-test-suite.js
@@ -19,9 +19,9 @@ const testServer = require('../../../utils/test-server.js');
 
 const RETRIES = 3;
 const TIMEOUT = 10 * 1000;
-const packageName = 'sw-cacheable-response';
+const PACKAGE_NAME = 'sw-cacheable-response';
 
-describe(`${packageName} Browser Tests`, function() {
+describe(`${PACKAGE_NAME} Browser Tests`, function() {
   this.retries(RETRIES);
   this.timeout(TIMEOUT);
 
@@ -30,7 +30,8 @@ describe(`${packageName} Browser Tests`, function() {
 
   // Set up the web server before running any tests in this suite.
   before(() => testServer.start('.').then((portNumber) => {
-    testHarnessUrl = `http://localhost:${portNumber}/__test/mocha/${packageName}`;
+    testHarnessUrl = `http://localhost:${portNumber}/__test/mocha/` +
+      PACKAGE_NAME;
   }));
 
   // Kill the web server once all tests are complete.

--- a/packages/sw-cacheable-response/test/browser/register-unit-tests.js
+++ b/packages/sw-cacheable-response/test/browser/register-unit-tests.js
@@ -1,0 +1,14 @@
+describe('Service Worker Unit Test Registration', function() {
+  const pathPrefix = '../sw/';
+  const swUnitTests = [
+    'cacheable-response.js',
+    'cacheable-response-plugin.js',
+    'namespace.js',
+  ].map((script) => `${pathPrefix}${script}`);
+
+  swUnitTests.forEach(function(swUnitTestPath) {
+    it(`should register ${swUnitTestPath}`, function() {
+      return goog.mochaUtils.registerServiceWorkerMochaTests(swUnitTestPath);
+    });
+  });
+});

--- a/packages/sw-cacheable-response/test/sw/cacheable-response-plugin.js
+++ b/packages/sw-cacheable-response/test/sw/cacheable-response-plugin.js
@@ -1,0 +1,28 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-cacheable-response/build/sw-cacheable-response.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('Test of the CacheableResponsePlugin class', function() {
+  const headers = {
+    'x-test': 'true',
+  };
+
+  it(`should extend the CacheableResponse class`, function() {
+    const plugin = new goog.cacheableResponse.CacheableResponsePlugin({headers});
+    expect(plugin).to.be.instanceOf(goog.cacheableResponse.CacheableResponse);
+  });
+
+  it(`should expose a the cacheWillUpdate() method`, function() {
+    const plugin = new goog.cacheableResponse.CacheableResponsePlugin({headers});
+    expect(plugin).to.respondTo('cacheWillUpdate');
+  });
+});

--- a/packages/sw-cacheable-response/test/sw/cacheable-response-plugin.js
+++ b/packages/sw-cacheable-response/test/sw/cacheable-response-plugin.js
@@ -12,17 +12,19 @@ mocha.setup({
 });
 
 describe('Test of the CacheableResponsePlugin class', function() {
-  const headers = {
+  const VALID_HEADERS = {
     'x-test': 'true',
   };
 
   it(`should extend the CacheableResponse class`, function() {
-    const plugin = new goog.cacheableResponse.CacheableResponsePlugin({headers});
+    const plugin = new goog.cacheableResponse.CacheableResponsePlugin(
+      {headers: VALID_HEADERS});
     expect(plugin).to.be.instanceOf(goog.cacheableResponse.CacheableResponse);
   });
 
   it(`should expose a the cacheWillUpdate() method`, function() {
-    const plugin = new goog.cacheableResponse.CacheableResponsePlugin({headers});
+    const plugin = new goog.cacheableResponse.CacheableResponsePlugin(
+      {headers: VALID_HEADERS});
     expect(plugin).to.respondTo('cacheWillUpdate');
   });
 });

--- a/packages/sw-cacheable-response/test/sw/cacheable-response.js
+++ b/packages/sw-cacheable-response/test/sw/cacheable-response.js
@@ -1,0 +1,108 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-cacheable-response/build/sw-cacheable-response.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('Test of the CacheableResponse class', function() {
+  const validStatus = 418;
+  const invalidStatus = 500;
+  const statuses = [validStatus];
+  const headers = {
+    'x-test': 'true',
+  };
+
+  it(`should throw when CacheableResponse() is called without any parameters`, function() {
+    let thrownError = null;
+    try {
+      new goog.cacheableResponse.CacheableResponse();
+    } catch(err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('atLeastOne');
+  });
+
+  it(`should throw when CacheableResponse() is called with an invalid 'statuses' parameter`, function() {
+    let thrownError = null;
+    try {
+      new goog.cacheableResponse.CacheableResponse({statuses: [null]});
+    } catch(err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('isArrayOfType');
+  });
+
+  it(`should throw when CacheableResponse() is called with an invalid 'headers' parameter`, function() {
+    let thrownError = null;
+    try {
+      new goog.cacheableResponse.CacheableResponse({headers: 0});
+    } catch(err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('isType');
+  });
+
+  it(`should throw when isResponseCacheable() is called with an invalid 'response' parameter`, function() {
+    let thrownError = null;
+    try {
+      const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses});
+      cacheableResponse.isResponseCacheable({response: null});
+    } catch(err) {
+      thrownError = err;
+    }
+    expect(thrownError).to.exist;
+    expect(thrownError.name).to.equal('isInstance');
+  });
+
+  it(`should return true when one of the 'statuses' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses});
+    const response = new Response('', {status: validStatus});
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.true;
+  });
+
+  it(`should return false when none of the 'statuses' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses});
+    const response = new Response('', {status: invalidStatus});
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
+  });
+
+  it(`should return true when one of the 'headers' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({headers});
+    const response = new Response('', {headers});
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.true;
+  });
+
+  it(`should return false when none of the 'headers' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({headers});
+    const response = new Response('');
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
+  });
+
+  it(`should return false when one of the 'statuses' parameter values match, but none of the 'headers' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses, headers});
+    const response = new Response('', {status: validStatus});
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
+  });
+
+  it(`should return false when one of the 'headers' parameter values match, but none of the 'statuses' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses, headers});
+    const response = new Response('', {headers, status: invalidStatus});
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
+  });
+
+  it(`should return true when both the 'headers' and 'statuses' parameter values match`, function() {
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses, headers});
+    const response = new Response('', {headers, status: validStatus});
+    expect(cacheableResponse.isResponseCacheable({response})).to.be.true;
+  });
+});

--- a/packages/sw-cacheable-response/test/sw/cacheable-response.js
+++ b/packages/sw-cacheable-response/test/sw/cacheable-response.js
@@ -12,10 +12,10 @@ mocha.setup({
 });
 
 describe('Test of the CacheableResponse class', function() {
-  const validStatus = 418;
-  const invalidStatus = 500;
-  const statuses = [validStatus];
-  const headers = {
+  const VALID_STATUS = 418;
+  const INVALID_STATUS = 500;
+  const VALID_STATUSES = [VALID_STATUS];
+  const VALID_HEADERS = {
     'x-test': 'true',
   };
 
@@ -55,7 +55,8 @@ describe('Test of the CacheableResponse class', function() {
   it(`should throw when isResponseCacheable() is called with an invalid 'response' parameter`, function() {
     let thrownError = null;
     try {
-      const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses});
+      const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+        {statuses: VALID_STATUSES});
       cacheableResponse.isResponseCacheable({response: null});
     } catch(err) {
       thrownError = err;
@@ -65,44 +66,51 @@ describe('Test of the CacheableResponse class', function() {
   });
 
   it(`should return true when one of the 'statuses' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses});
-    const response = new Response('', {status: validStatus});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {statuses: VALID_STATUSES});
+    const response = new Response('', {status: VALID_STATUS});
     expect(cacheableResponse.isResponseCacheable({response})).to.be.true;
   });
 
   it(`should return false when none of the 'statuses' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses});
-    const response = new Response('', {status: invalidStatus});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {statuses: VALID_STATUSES});
+    const response = new Response('', {status: INVALID_STATUS});
     expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
   });
 
   it(`should return true when one of the 'headers' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({headers});
-    const response = new Response('', {headers});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {headers: VALID_HEADERS});
+    const response = new Response('', {headers: VALID_HEADERS});
     expect(cacheableResponse.isResponseCacheable({response})).to.be.true;
   });
 
   it(`should return false when none of the 'headers' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({headers});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {headers: VALID_HEADERS});
     const response = new Response('');
     expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
   });
 
   it(`should return false when one of the 'statuses' parameter values match, but none of the 'headers' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses, headers});
-    const response = new Response('', {status: validStatus});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {statuses: VALID_STATUSES, headers: VALID_HEADERS});
+    const response = new Response('', {status: VALID_STATUS});
     expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
   });
 
   it(`should return false when one of the 'headers' parameter values match, but none of the 'statuses' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses, headers});
-    const response = new Response('', {headers, status: invalidStatus});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {statuses: VALID_STATUSES, headers: VALID_HEADERS});
+    const response = new Response('', {headers: VALID_HEADERS, status: INVALID_STATUS});
     expect(cacheableResponse.isResponseCacheable({response})).to.be.false;
   });
 
   it(`should return true when both the 'headers' and 'statuses' parameter values match`, function() {
-    const cacheableResponse = new goog.cacheableResponse.CacheableResponse({statuses, headers});
-    const response = new Response('', {headers, status: validStatus});
+    const cacheableResponse = new goog.cacheableResponse.CacheableResponse(
+      {VALID_STATUSES, headers: VALID_HEADERS});
+    const response = new Response('', {headers: VALID_HEADERS, status: VALID_STATUS});
     expect(cacheableResponse.isResponseCacheable({response})).to.be.true;
   });
 });

--- a/packages/sw-cacheable-response/test/sw/namespace.js
+++ b/packages/sw-cacheable-response/test/sw/namespace.js
@@ -1,0 +1,29 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-cacheable-response/build/sw-cacheable-response.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+const exportedSymbols = [
+  'CacheableResponse',
+  'CacheableResponsePlugin',
+];
+
+describe('Test Library Surface', function() {
+  it('should be accessible via goog.cacheableResponse', function() {
+    expect(goog.cacheableResponse).to.exist;
+  });
+
+  exportedSymbols.forEach((exportedSymbol) => {
+    it(`should expose ${exportedSymbol} via goog.cacheableResponse`, function() {
+      expect(goog.cacheableResponse[exportedSymbol]).to.exist;
+    });
+  });
+});

--- a/packages/sw-lib/src/lib/sw-lib.js
+++ b/packages/sw-lib/src/lib/sw-lib.js
@@ -25,7 +25,7 @@ import {Plugin as CacheExpirationPlugin} from
   '../../../sw-cache-expiration/src/index.js';
 import {BroadcastCacheUpdatePlugin} from
   '../../../sw-broadcast-cache-update/src/index.js';
-import {Plugin as CacheableResponsePlugin} from
+import {CacheableResponsePlugin} from
   '../../../sw-cacheable-response/src/index.js';
 import {
   CacheFirst, CacheOnly, NetworkFirst,


### PR DESCRIPTION
R: @addyosmani @gauntface

This is part of #282, in which the Plugin classes are refactored to extend a base class, and expose the lifecycle methods.

In addition to refactoring, it also adds tests, as this module was previously untested.