### PR TITLE
Split up the CacheExpiration and CacheExpirationPlugin classes.

### DIFF
--- a/packages/sw-cache-expiration/src/index.js
+++ b/packages/sw-cache-expiration/src/index.js
@@ -49,10 +49,12 @@
  */
 
 import {timestampPropertyName, urlPropertyName} from './lib/constants';
-import Plugin from './lib/plugin';
+import CacheExpiration from './lib/cache-expiration';
+import CacheExpirationPlugin from './lib/cache-expiration-plugin';
 
 export {
   timestampPropertyName,
   urlPropertyName,
-  Plugin,
+  CacheExpiration,
+  CacheExpirationPlugin,
 };

--- a/packages/sw-cache-expiration/src/lib/cache-expiration-plugin.js
+++ b/packages/sw-cache-expiration/src/lib/cache-expiration-plugin.js
@@ -1,0 +1,88 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import CacheExpiration from './cache-expiration';
+import assert from '../../../../lib/assert';
+
+/**
+ * The `CacheExpirationPlugin` class allows you define an expiration and / or
+ * limit on the responses cached.
+ *
+ * This class is meant to be automatically invoked as a plugin to a
+ * {@link module:sw-runtime-caching.RequestWrapper|RequestWrapper}, which is
+ * used by the `sw-lib` and `sw-runtime-caching` modules.
+ *
+ * If you would like to use this functionality outside of the `RequestWrapper`
+ * context, please use the `CacheExpiration` class directly.
+ *
+ * @example
+ * const plugin = new goog.cacheExpiration.CacheExpirationPlugin({
+ *   maxEntries: 2,
+ *   maxAgeSeconds: 10,
+ * });
+ *
+ * @memberof module:sw-cache-expiration
+ */
+class CacheExpirationPlugin extends CacheExpiration {
+  /**
+   * A "lifecycle" callback that will be triggered automatically by the
+   * `goog.runtimeCaching` handlers when a `Response` is about to be returned
+   * from a [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache) to
+   * the handler. It allows the `Response` to be inspected for freshness and
+   * prevents it from being used if the `Response`'s `Date` header value is
+   * older than the configured `maxAgeSeconds`.
+   *
+   * @private
+   * @param {Object} input
+   * @param {Response} input.cachedResponse The `Response` object that's been
+   *        read from a cache and whose freshness should be checked.
+   * @param {Number} [input.now] A timestamp. Defaults to the current time.
+   * @return {Response|null} Either the `cachedResponse`, if it's fresh, or
+   *          `null` if the `Response` is older than `maxAgeSeconds`.
+   */
+  cacheWillMatch({cachedResponse, now} = {}) {
+    if (this.isResponseFresh({cachedResponse, now})) {
+      return cachedResponse;
+    }
+
+    return null;
+  }
+
+  /**
+   * A "lifecycle" callback that will be triggered automatically by the
+   * `goog.runtimeCaching` handlers when an entry is added to a cache.
+   *
+   * @private
+   * @param {Object} input
+   * @param {string} input.cacheName Name of the cache the responses belong to.
+   * @param {Response} input.newResponse The new value in the cache.
+   * @param {string} input.url The URL for the cache entry.
+   * @param {Number} [input.now] A timestamp. Defaults to the current time.
+   */
+  cacheDidUpdate({cacheName, newResponse, url, now} = {}) {
+    assert.isType({cacheName}, 'string');
+    assert.isInstance({newResponse}, Response);
+
+    if (typeof now === 'undefined') {
+      now = Date.now();
+    }
+
+    this.updateTimestamp({cacheName, url, now}).then(() => {
+      this.expireEntries({cacheName, now});
+    });
+  }
+}
+
+export default CacheExpirationPlugin;

--- a/packages/sw-cache-expiration/test/browser/register-unit-tests.js
+++ b/packages/sw-cache-expiration/test/browser/register-unit-tests.js
@@ -1,7 +1,9 @@
 describe('Service Worker Unit Test Registration', function() {
   const pathPrefix = '../sw/';
   const swUnitTests = [
-    'plugin.js',
+    'namespace.js',
+    'cache-expiration.js',
+    'cache-expiration-plugin.js',
   ].map((script) => `${pathPrefix}${script}`);
 
   swUnitTests.forEach(function(swUnitTestPath) {

--- a/packages/sw-cache-expiration/test/sw/cache-expiration-plugin.js
+++ b/packages/sw-cache-expiration/test/sw/cache-expiration-plugin.js
@@ -1,0 +1,52 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-cache-expiration/build/sw-cache-expiration.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('Test of the CacheExpirationPlugin class', function() {
+  const MAX_AGE_SECONDS = 3;
+  const NOW = 1487106334920;
+
+  it(`should extend the CacheExpiration class`, function() {
+    const plugin = new goog.cacheExpiration.CacheExpirationPlugin(
+      {maxAgeSeconds: MAX_AGE_SECONDS});
+    expect(plugin).to.be.instanceOf(goog.cacheExpiration.CacheExpiration);
+  });
+
+  it(`should expose a cacheWillMatch() method`, function() {
+    const plugin = new goog.cacheExpiration.CacheExpirationPlugin(
+      {maxAgeSeconds: MAX_AGE_SECONDS});
+    expect(plugin).to.respondTo('cacheWillMatch');
+  });
+
+  it(`should expose a cacheDidUpdate() method`, function() {
+    const plugin = new goog.cacheExpiration.CacheExpirationPlugin(
+      {maxAgeSeconds: MAX_AGE_SECONDS});
+    expect(plugin).to.respondTo('cacheDidUpdate');
+  });
+
+  it(`should return cachedResponse when cacheWillMatch() is called and isResponseFresh() is true`, function() {
+    const plugin = new goog.cacheExpiration.CacheExpirationPlugin(
+      {maxAgeSeconds: MAX_AGE_SECONDS});
+    const date = new Date(NOW).toUTCString();
+    const cachedResponse = new Response('', {headers: {date}});
+    expect(plugin.cacheWillMatch({cachedResponse, now: NOW})).to.eql(cachedResponse);
+  });
+
+  it(`should return null when cacheWillMatch() is called and isResponseFresh() is false`, function() {
+    const plugin = new goog.cacheExpiration.CacheExpirationPlugin(
+      {maxAgeSeconds: MAX_AGE_SECONDS});
+    // This will construct a date that is 1 second past the expiration.
+    const date = new Date(NOW - ((MAX_AGE_SECONDS + 1) * 1000)).toUTCString();
+    const cachedResponse = new Response('', {headers: {date}});
+    expect(plugin.cacheWillMatch({cachedResponse, now: NOW})).to.be.null;
+  });
+});

--- a/packages/sw-cache-expiration/test/sw/cache-expiration.js
+++ b/packages/sw-cache-expiration/test/sw/cache-expiration.js
@@ -19,19 +19,19 @@ function getUniqueCacheName() {
   return 'test-cache-' + count++;
 }
 
-describe('Test of the Plugin class', function() {
-  const maxAgeSeconds = 3;
-  const maxEntries = 3;
-  const now = 1487106334920;
+describe('Test of the CacheExpiration class', function() {
+  const MAX_AGE_SECONDS = 3;
+  const MAX_ENTRIES = 3;
+  const NOW = 1487106334920;
+
   const timestampPropertyName = goog.cacheExpiration.timestampPropertyName;
   const urlPropertyName = goog.cacheExpiration.urlPropertyName;
+  const CacheExpiration = goog.cacheExpiration.CacheExpiration;
 
-  const Plugin = goog.cacheExpiration.Plugin;
-
-  it(`should throw when Plugin() is called without any parameters`, function() {
+  it(`should throw when CacheExpiration() is called without any parameters`, function() {
     let thrownError = null;
     try {
-      new Plugin();
+      new CacheExpiration();
     } catch(err) {
       thrownError = err;
     }
@@ -40,10 +40,10 @@ describe('Test of the Plugin class', function() {
     expect(thrownError.name).to.equal('max-entries-or-age-required');
   });
 
-  it(`should throw when Plugin() is called with an invalid maxEntries parameter`, function() {
+  it(`should throw when CacheExpiration() is called with an invalid maxEntries parameter`, function() {
     let thrownError = null;
     try {
-      new Plugin({maxEntries: 'invalid'});
+      new CacheExpiration({maxEntries: 'invalid'});
     } catch(err) {
       thrownError = err;
     }
@@ -51,10 +51,10 @@ describe('Test of the Plugin class', function() {
     expect(thrownError.name).to.equal('max-entries-must-be-number');
   });
 
-  it(`should throw when Plugin() is called with an invalid maxAgeSeconds parameter`, function() {
+  it(`should throw when CacheExpiration() is called with an invalid maxAgeSeconds parameter`, function() {
     let thrownError = null;
     try {
-      new Plugin({maxAgeSeconds: 'invalid'});
+      new CacheExpiration({maxAgeSeconds: 'invalid'});
     } catch(err) {
       thrownError = err;
     }
@@ -63,18 +63,18 @@ describe('Test of the Plugin class', function() {
   });
 
   it(`should use the maxAgeSeconds from the constructor`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
-    expect(plugin.maxAgeSeconds).to.equal(maxAgeSeconds);
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
+    expect(plugin.maxAgeSeconds).to.equal(MAX_AGE_SECONDS);
   });
 
   it(`should use the maxEntries from the constructor`, function() {
-    const plugin = new Plugin({maxEntries});
-    expect(plugin.maxEntries).to.equal(maxEntries);
+    const plugin = new CacheExpiration({maxEntries: MAX_ENTRIES});
+    expect(plugin.maxEntries).to.equal(MAX_ENTRIES);
   });
 
   it(`should return the same IDB instance when getDB() is called multiple times`, function() {
     const cacheName = getUniqueCacheName();
-    const plugin = new Plugin({maxEntries});
+    const plugin = new CacheExpiration({maxEntries: MAX_ENTRIES});
     return plugin.getDB({cacheName}).then((firstDB) => {
       return plugin.getDB({cacheName}).then((secondDB) => {
         expect(firstDB).to.eql(secondDB);
@@ -84,7 +84,7 @@ describe('Test of the Plugin class', function() {
 
   it(`should return the same Cache instance when getCache() is called multiple times`, function() {
     const cacheName = getUniqueCacheName();
-    const plugin = new Plugin({maxEntries});
+    const plugin = new CacheExpiration({maxEntries: MAX_ENTRIES});
     return plugin.getCache({cacheName}).then((firstCache) => {
       return plugin.getCache({cacheName}).then((secondCache) => {
         expect(firstCache).to.eql(secondCache);
@@ -93,75 +93,60 @@ describe('Test of the Plugin class', function() {
   });
 
   it(`should return true when there's no cachedResponse passed to isResponseFresh()`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
     expect(plugin.isResponseFresh()).to.be.true;
   });
 
   it(`should return true when isResponseFresh() is called and there's no maxAgeSeconds`, function() {
-    const plugin = new Plugin({maxEntries});
+    const plugin = new CacheExpiration({maxEntries: MAX_ENTRIES});
     const cachedResponse = new Response();
     expect(plugin.isResponseFresh({cachedResponse})).to.be.true;
   });
 
   it(`should return true when isResponseFresh() is called and there's no Date: header in the cachedResponse`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
     const cachedResponse = new Response();
     expect(plugin.isResponseFresh({cachedResponse})).to.be.true;
   });
 
   it(`should return true when isResponseFresh() is called and the Date: header in the cachedResponse is recent`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
-    const date = new Date(now).toUTCString();
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
+    const date = new Date(NOW).toUTCString();
     const cachedResponse = new Response('', {headers: {date}});
-    expect(plugin.isResponseFresh({cachedResponse, now})).to.be.true;
+    expect(plugin.isResponseFresh({cachedResponse, now: NOW})).to.be.true;
   });
 
   it(`should return false when isResponseFresh() is called and the Date: header in the cachedResponse is not recent`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
     // This will construct a date that is 1 second past the expiration.
-    const date = new Date(now - ((maxAgeSeconds + 1) * 1000)).toUTCString();
+    const date = new Date(NOW - ((MAX_AGE_SECONDS + 1) * 1000)).toUTCString();
     const cachedResponse = new Response('', {headers: {date}});
-    expect(plugin.isResponseFresh({cachedResponse, now})).to.be.false;
-  });
-
-  it(`should return cachedResponse when cacheWillMatch() is called and isResponseFresh() is true`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
-    const date = new Date(now).toUTCString();
-    const cachedResponse = new Response('', {headers: {date}});
-    expect(plugin.cacheWillMatch({cachedResponse, now})).to.eql(cachedResponse);
-  });
-
-  it(`should return null when cacheWillMatch() is called and isResponseFresh() is false`, function() {
-    const plugin = new Plugin({maxAgeSeconds});
-    // This will construct a date that is 1 second past the expiration.
-    const date = new Date(now - ((maxAgeSeconds + 1) * 1000)).toUTCString();
-    const cachedResponse = new Response('', {headers: {date}});
-    expect(plugin.cacheWillMatch({cachedResponse, now})).to.be.null;
+    expect(plugin.isResponseFresh({cachedResponse, now: NOW})).to.be.false;
   });
 
   it(`should update IndexedDB when updateTimestamp() is called`, function() {
     const cacheName = getUniqueCacheName();
-    const plugin = new Plugin({maxAgeSeconds});
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
     const url = getUniqueUrl();
 
-    return plugin.updateTimestamp({cacheName, url, now})
+    return plugin.updateTimestamp({cacheName, url, now: NOW})
       .then(() => plugin.getDB({cacheName}))
       .then((db) => {
         const tx = db.transaction(cacheName, 'readonly');
         const store = tx.objectStore(cacheName);
         return store.get(url);
-      }).then((entry) => expect(entry[timestampPropertyName]).to.equal(now));
+      }).then((entry) => expect(entry[timestampPropertyName]).to.equal(NOW));
   });
 
   it(`should only find expired entries when findOldEntries() is called`, function() {
     const cacheName = getUniqueCacheName();
-    const plugin = new Plugin({maxAgeSeconds});
+    const plugin = new CacheExpiration({maxAgeSeconds: MAX_AGE_SECONDS});
     const firstStaleUrl = getUniqueUrl();
     const secondStaleUrl = getUniqueUrl();
     const firstFreshUrl = getUniqueUrl();
     const secondFreshUrl = getUniqueUrl();
-    const freshNow = now - (maxAgeSeconds - 1) * 1000;
-    const staleNow = now - (maxAgeSeconds + 1) * 1000;
+    const freshNow = NOW - (MAX_AGE_SECONDS - 1) * 1000;
+    const staleNow = NOW - (MAX_AGE_SECONDS + 1) * 1000;
     const updatePromises = [
       plugin.updateTimestamp({cacheName, url: firstFreshUrl, now: freshNow}),
       plugin.updateTimestamp({cacheName, url: secondFreshUrl, now: freshNow}),
@@ -170,40 +155,40 @@ describe('Test of the Plugin class', function() {
     ];
 
     return Promise.all(updatePromises)
-      .then(() => plugin.findOldEntries({cacheName, now}))
+      .then(() => plugin.findOldEntries({cacheName, now: NOW}))
       .then((oldEntries) => expect(oldEntries).to.eql([firstStaleUrl, secondStaleUrl]));
   });
 
   it(`should find only extra entries when findExtraEntries() is called`, function() {
     const cacheName = getUniqueCacheName();
-    const plugin = new Plugin({maxEntries});
+    const plugin = new CacheExpiration({maxEntries: MAX_ENTRIES});
     const urls = [];
     const extraEntryCount = 2;
-    for (let i = 0; i < maxEntries + extraEntryCount; i++) {
+    for (let i = 0; i < MAX_ENTRIES + extraEntryCount; i++) {
       urls.push(getUniqueUrl());
     }
     const updatePromises = urls.map((url, i) => plugin.updateTimestamp({
-      cacheName, url, now: now + i}));
+      cacheName, url, now: NOW + i}));
 
     return Promise.all(updatePromises)
       .then(() => plugin.findExtraEntries({cacheName}))
       .then((extraEntries) => expect(extraEntries).to.eql(urls.slice(0, extraEntryCount)))
       // Test again with the urls[0] value updated, so that it's no longer the oldest.
-      .then(() => plugin.updateTimestamp({cacheName, url: urls[0], now: now + maxEntries}))
+      .then(() => plugin.updateTimestamp({cacheName, url: urls[0], now: NOW + MAX_ENTRIES}))
       .then(() => plugin.findExtraEntries({cacheName}))
       .then((extraEntries) => expect(extraEntries).to.eql(urls.slice(1, extraEntryCount + 1)));
   });
 
   it(`should delete expired entries when deleteFromCacheAndIDB() is called`, function() {
     const cacheName = getUniqueCacheName();
-    const plugin = new Plugin({maxEntries});
+    const plugin = new CacheExpiration({maxEntries: MAX_ENTRIES});
     const urls = [];
     const extraEntryCount = 2;
-    for (let i = 0; i < maxEntries + extraEntryCount; i++) {
+    for (let i = 0; i < MAX_ENTRIES + extraEntryCount; i++) {
       urls.push(getUniqueUrl());
     }
     const updatePromises = urls.map((url, i) => plugin.updateTimestamp({
-      cacheName, url, now: now + i}));
+      cacheName, url, now: NOW + i}));
 
     return Promise.all(updatePromises)
       .then(() => caches.open(cacheName))

--- a/packages/sw-cache-expiration/test/sw/namespace.js
+++ b/packages/sw-cache-expiration/test/sw/namespace.js
@@ -1,0 +1,31 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-cache-expiration/build/sw-cache-expiration.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+const exportedSymbols = [
+  'timestampPropertyName',
+  'urlPropertyName',
+  'CacheExpiration',
+  'CacheExpirationPlugin',
+];
+
+describe('Test Library Surface', function() {
+  it('should be accessible via goog.cacheExpiration', function() {
+    expect(goog.cacheExpiration).to.exist;
+  });
+
+  exportedSymbols.forEach((exportedSymbol) => {
+    it(`should expose ${exportedSymbol} via goog.cacheExpiration`, function() {
+      expect(goog.cacheExpiration[exportedSymbol]).to.exist;
+    });
+  });
+});

--- a/packages/sw-lib/src/lib/strategies.js
+++ b/packages/sw-lib/src/lib/strategies.js
@@ -2,7 +2,7 @@ import {
   CacheFirst, CacheOnly, NetworkFirst,
   NetworkOnly, StaleWhileRevalidate,
 } from '../../../sw-runtime-caching/src/index.js';
-import {Plugin as CacheExpirationPlugin} from
+import {CacheExpirationPlugin} from
   '../../../sw-cache-expiration/src/index.js';
 import {BroadcastCacheUpdatePlugin} from
   '../../../sw-broadcast-cache-update/src/index.js';


### PR DESCRIPTION
R: @addyosmani @gauntface 

This is part of #282, in which the Plugin classes are refactored to extend a base class, and expose the lifecycle methods.