### PR TITLE
Small change to the redirected browser test URL

### DIFF
--- a/utils/server-instance.js
+++ b/utils/server-instance.js
@@ -145,15 +145,16 @@ class ServerInstance {
       res.send(html);
     });
 
-    // Redirect /packages/:pkg/test/browser/ to the /__test/mocha/:pkg templated
-    // page, but only if there's no /packages/:pkg/test/browser/index.html
+    // Redirect /packages/:pkg/test/browser/ to the /__test/mocha/browser/:pkg
+    // templated page, but only if there's no
+    // /packages/:pkg/test/browser/index.html
     this._app.get('/packages/:pkg/test/browser/', function(req, res, next) {
       const index = path.join(__dirname, '..', 'packages', req.params.pkg,
         'test', 'browser', 'index.html');
       if (fs.existsSync(index)) {
         next();
       } else {
-        res.redirect(301, `/__test/mocha/${req.params.pkg}`);
+        res.redirect(301, `/__test/mocha/browser/${req.params.pkg}`);
       }
     });
   }


### PR DESCRIPTION
R: @addyosmani @gauntface

Small change to account for the current URL pattern used for kicking off browser tests. This redirect is useful when manually browsing the directory listing page for a package and starting tests manually.