### PR TITLE
Save plugin references and call methods on them

### DIFF
--- a/packages/sw-lib/test/sw/caching-strategies.js
+++ b/packages/sw-lib/test/sw/caching-strategies.js
@@ -74,8 +74,8 @@ describe('Test caching strategies.', function() {
       });
       expect(handler.handle).to.exist;
       expect(handler.requestWrapper).to.exist;
-      expect(handler.requestWrapper.pluginCallbacks.cacheDidUpdate).to.exist;
-      handler.requestWrapper.pluginCallbacks.cacheDidUpdate.length.should.equal(1);
+      expect(handler.requestWrapper.plugins.has('cacheDidUpdate')).to.be.true;
+      handler.requestWrapper.plugins.get('cacheDidUpdate').length.should.equal(1);
     });
 
     it(`should return a Handler when '${strategy}' is instantiated with broadcastCacheUpdate options`, function() {
@@ -88,8 +88,8 @@ describe('Test caching strategies.', function() {
       });
       expect(handler.handle).to.exist;
       expect(handler.requestWrapper).to.exist;
-      expect(handler.requestWrapper.pluginCallbacks.cacheDidUpdate).to.exist;
-      handler.requestWrapper.pluginCallbacks.cacheDidUpdate.length.should.equal(1);
+      expect(handler.requestWrapper.plugins.has('cacheDidUpdate')).to.be.true;
+      handler.requestWrapper.plugins.get('cacheDidUpdate').length.should.equal(1);
     });
 
     it(`should return a Handler when '${strategy}' is instantiated with cacheableResponse options`, function() {
@@ -105,7 +105,7 @@ describe('Test caching strategies.', function() {
       });
       expect(handler.handle).to.exist;
       expect(handler.requestWrapper).to.exist;
-      expect(handler.requestWrapper.pluginCallbacks.cacheWillUpdate).to.exist;
+      expect(handler.requestWrapper.plugins.has('cacheWillUpdate')).to.be.true;
     });
   });
 });

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -74,7 +74,7 @@ class RequestWrapper {
       this.matchOptions = matchOptions;
     }
 
-    this.pluginCallbacks = {};
+    this.plugins = new Map();
 
     if (plugins) {
       assert.isArrayOfType({plugins}, 'object');
@@ -82,26 +82,23 @@ class RequestWrapper {
       plugins.forEach((plugin) => {
         for (let callbackName of pluginCallbacks) {
           if (typeof plugin[callbackName] === 'function') {
-            if (!this.pluginCallbacks[callbackName]) {
-              this.pluginCallbacks[callbackName] = [];
+            if (!this.plugins.has(callbackName)) {
+              this.plugins.set(callbackName, []);
             }
-            this.pluginCallbacks[callbackName].push(
-              plugin[callbackName].bind(plugin));
+            this.plugins.get(callbackName).push(plugin);
           }
         }
       });
     }
 
-    if (this.pluginCallbacks.cacheWillUpdate) {
-      if (this.pluginCallbacks.cacheWillUpdate.length !== 1) {
-        throw ErrorFactory.createError('multiple-cache-will-update-plugins');
-      }
+    if (this.plugins.has('cacheWillUpdate') &&
+        this.plugins.get('cacheWillUpdate').length !== 1) {
+      throw ErrorFactory.createError('multiple-cache-will-update-plugins');
     }
 
-    if (this.pluginCallbacks.cacheWillMatch) {
-      if (this.pluginCallbacks.cacheWillMatch.length !== 1) {
-        throw ErrorFactory.createError('multiple-cache-will-match-plugins');
-      }
+    if (this.plugins.has('cacheWillMatch') &&
+      this.plugins.get('cacheWillMatch').length !== 1) {
+      throw ErrorFactory.createError('multiple-cache-will-match-plugins');
     }
   }
 
@@ -149,9 +146,9 @@ class RequestWrapper {
     const cache = await this.getCache();
     let cachedResponse = await cache.match(request, this.matchOptions);
 
-    if (this.pluginCallbacks.cacheWillMatch) {
-      cachedResponse = this.pluginCallbacks.cacheWillMatch[0](
-        {cachedResponse});
+    if (this.plugins.has('cacheWillMatch')) {
+      const plugin = this.plugins.get('cacheWillMatch')[0];
+      cachedResponse = plugin.cacheWillMatch({cachedResponse});
     }
 
     return cachedResponse;
@@ -184,11 +181,11 @@ class RequestWrapper {
       assert.isInstance({request}, Request);
     }
 
-    const clonedRequest = this.pluginCallbacks.fetchDidFail ?
+    const clonedRequest = this.plugins.has('fetchDidFail') ?
       request.clone() : null;
-    if (this.pluginCallbacks.requestWillFetch) {
-      for (let callback of this.pluginCallbacks.requestWillFetch) {
-        const returnedPromise = callback({request});
+    if (this.plugins.has('requestWillFetch')) {
+      for (let plugin of this.plugins.get('requestWillFetch')) {
+        const returnedPromise = plugin.requestWillFetch({request});
         assert.isInstance({returnedPromise}, Promise);
         const returnedRequest = await returnedPromise;
         assert.isInstance({returnedRequest}, Request);
@@ -199,9 +196,9 @@ class RequestWrapper {
     try {
       return await fetch(request, this.fetchOptions);
     } catch (err) {
-      if (this.pluginCallbacks.fetchDidFail) {
-        for (let callback of this.pluginCallbacks.fetchDidFail) {
-          callback({request: clonedRequest.clone()});
+      if (this.plugins.has('fetchDidFail')) {
+        for (let plugin of this.plugins.get('fetchDidFail')) {
+          plugin.fetchDidFail({request: clonedRequest.clone()});
         }
       }
 
@@ -249,9 +246,9 @@ class RequestWrapper {
     // response.ok is true if the response status is 2xx.
     // That's the default condition.
     let cacheable = response.ok;
-    if (this.pluginCallbacks.cacheWillUpdate) {
-      cacheable = this.pluginCallbacks.cacheWillUpdate[0](
-        {request, response});
+    if (this.plugins.has('cacheWillUpdate')) {
+      const plugin = this.plugins.get('cacheWillUpdate')[0];
+      cacheable = plugin.cacheWillUpdate({request, response});
     }
 
     if (cacheable) {
@@ -266,7 +263,7 @@ class RequestWrapper {
         // and there's at least one cacheDidUpdateCallbacks. Otherwise, we don't
         // need it.
         if (response.type !== 'opaque' &&
-          this.pluginCallbacks.cacheDidUpdate) {
+          this.plugins.has('cacheDidUpdate')) {
           oldResponse = await this.match({request});
         }
 
@@ -275,13 +272,15 @@ class RequestWrapper {
         const cacheRequest = cacheKey || request;
         await cache.put(cacheRequest, newResponse);
 
-        for (let callback of (this.pluginCallbacks.cacheDidUpdate || [])) {
-          callback({
-            cacheName: this.cacheName,
-            oldResponse,
-            newResponse,
-            url: request.url,
-          });
+        if (this.plugins.has('cacheDidUpdate')) {
+          for (let plugin of this.plugins.get('cacheDidUpdate')) {
+            plugin.cacheDidUpdate({
+              cacheName: this.cacheName,
+              oldResponse,
+              newResponse,
+              url: request.url,
+            });
+          }
         }
       });
     } else if (!cacheable) {


### PR DESCRIPTION
R: @addyosmani @gauntface

I'm addressing some of the feedback from https://github.com/GoogleChrome/sw-helpers/pull/399 out of band, as it extends past the boundaries of that PR.

This moves away from `RequestWrapper` saving and then invoking references to the bound functions exposed by plugins, and instead saves references to the plugins themselves, and calls the methods on the plugin instances directly.

The tests confirm that this shouldn't change any behavior.