### PR TITLE
Properly wait on IDB deletion & E2E tests for cache expiration

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",
     "sinon": "^1.17.6",
-    "sw-testing-helpers": "1.0.1",
+    "sw-testing-helpers": "^1.0.2",
     "tmp": "0.0.31"
   }
 }

--- a/packages/sw-cache-expiration/package.json
+++ b/packages/sw-cache-expiration/package.json
@@ -23,5 +23,8 @@
   "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-cache-expiration",
   "main": "build/sw-cache-expiration.min.js",
   "module": "build/sw-cache-expiration.min.mjs",
-  "jsnext:main": "build/sw-cache-expiration.min.mjs"
+  "jsnext:main": "build/sw-cache-expiration.min.mjs",
+  "devDependencies": {
+    "sw-runtime-caching": "^0.0.18"
+  }
 }

--- a/packages/sw-cache-expiration/src/lib/cache-expiration-plugin.js
+++ b/packages/sw-cache-expiration/src/lib/cache-expiration-plugin.js
@@ -71,7 +71,7 @@ class CacheExpirationPlugin extends CacheExpiration {
    * @param {string} input.url The URL for the cache entry.
    * @param {Number} [input.now] A timestamp. Defaults to the current time.
    */
-  cacheDidUpdate({cacheName, newResponse, url, now} = {}) {
+  async cacheDidUpdate({cacheName, newResponse, url, now} = {}) {
     assert.isType({cacheName}, 'string');
     assert.isInstance({newResponse}, Response);
 
@@ -79,9 +79,8 @@ class CacheExpirationPlugin extends CacheExpiration {
       now = Date.now();
     }
 
-    this.updateTimestamp({cacheName, url, now}).then(() => {
-      this.expireEntries({cacheName, now});
-    });
+    await this.updateTimestamp({cacheName, url, now});
+    await this.expireEntries({cacheName, now});
   }
 }
 

--- a/packages/sw-cache-expiration/test/browser/end-to-end.js
+++ b/packages/sw-cache-expiration/test/browser/end-to-end.js
@@ -7,7 +7,8 @@ describe(`End to End Test of Cache Expiration`, function() {
   beforeEach(() => goog.swUtils.cleanState());
 
   it(`should work properly when there are many simultaneous requests`, async function() {
-    const iframe = await goog.swUtils.controlledBySW('../static/cache-expiration.js');
+    const iframe = await goog.swUtils.controlledBySW(
+      '/packages/sw-cache-expiration/test/static/cache-expiration.js');
 
     const fetchPromises = [];
     for (let i = 0; i < NUMBER_OF_REQUESTS; i++) {
@@ -23,7 +24,8 @@ describe(`End to End Test of Cache Expiration`, function() {
   });
 
   it(`should work properly when there are many sequential requests`, async function() {
-    const iframe = await goog.swUtils.controlledBySW('../static/cache-expiration.js');
+    const iframe = await goog.swUtils.controlledBySW(
+      '/packages/sw-cache-expiration/test/static/cache-expiration.js');
 
     for (let i = 0; i < NUMBER_OF_REQUESTS; i++) {
       const url = `${BASE_URL}?param=${i}`;

--- a/packages/sw-cache-expiration/test/browser/end-to-end.js
+++ b/packages/sw-cache-expiration/test/browser/end-to-end.js
@@ -1,0 +1,38 @@
+describe(`End to End Test of Cache Expiration`, function() {
+  const BASE_URL = '/__echo/counter';
+  const NUMBER_OF_REQUESTS = 15;
+  const CACHE_NAME = 'cache-expiration';
+  const EXPECTED_CACHE_SIZE = 5;
+
+  beforeEach(() => goog.swUtils.cleanState());
+
+  it(`should work properly when there are many simultaneous requests`, async function() {
+    const iframe = await goog.swUtils.controlledBySW('../static/cache-expiration.js');
+
+    const fetchPromises = [];
+    for (let i = 0; i < NUMBER_OF_REQUESTS; i++) {
+      const url = `${BASE_URL}?param=${i}`;
+      fetchPromises.push(iframe.contentWindow.fetch(url));
+    }
+    await Promise.all(fetchPromises);
+
+    const cache = await caches.open(CACHE_NAME);
+    const keys = await cache.keys();
+
+    expect(keys).to.have.length(EXPECTED_CACHE_SIZE);
+  });
+
+  it(`should work properly when there are many sequential requests`, async function() {
+    const iframe = await goog.swUtils.controlledBySW('../static/cache-expiration.js');
+
+    for (let i = 0; i < NUMBER_OF_REQUESTS; i++) {
+      const url = `${BASE_URL}?param=${i}`;
+      await iframe.contentWindow.fetch(url);
+    }
+
+    const cache = await caches.open(CACHE_NAME);
+    const keys = await cache.keys();
+
+    expect(keys).to.have.length(EXPECTED_CACHE_SIZE);
+  });
+});

--- a/packages/sw-cache-expiration/test/static/cache-expiration.js
+++ b/packages/sw-cache-expiration/test/static/cache-expiration.js
@@ -1,4 +1,4 @@
-importScripts('/packages/sw-runtime-caching/build/sw-runtime-caching.js');
+importScripts('/packages/sw-cache-expiration/node_modules/sw-runtime-caching/build/sw-runtime-caching.js');
 importScripts('/packages/sw-cache-expiration/build/sw-cache-expiration.js');
 
 self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));

--- a/packages/sw-cache-expiration/test/static/cache-expiration.js
+++ b/packages/sw-cache-expiration/test/static/cache-expiration.js
@@ -1,0 +1,23 @@
+importScripts('/packages/sw-runtime-caching/build/sw-runtime-caching.js');
+importScripts('/packages/sw-cache-expiration/build/sw-cache-expiration.js');
+
+self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+
+const cacheExpirationPlugin= new goog.cacheExpiration.CacheExpirationPlugin({
+  maxEntries: 5,
+});
+const requestWrapper = new goog.runtimeCaching.RequestWrapper({
+  cacheName: 'cache-expiration',
+  plugins: [cacheExpirationPlugin],
+});
+const handler = new goog.runtimeCaching.CacheFirst({
+  requestWrapper,
+  waitOnCache: true,
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.includes('/__echo/counter')) {
+    event.respondWith(handler.handle({event}));
+  }
+});

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -261,13 +261,13 @@ class RequestWrapper {
     if (cacheable) {
       const newResponse = response.clone();
 
-      // cacheDelay is a promise that may or may not be used to delay the
+      // cachingComplete is a promise that may or may not be used to delay the
       // completion of this method, depending on the value of `waitOnCache`.
       cachingComplete = this.getCache().then(async (cache) => {
         let oldResponse;
 
         // Only bother getting the old response if the new response isn't opaque
-        // and there's at least one cacheDidUpdateCallbacks. Otherwise, we don't
+        // and there's at least one cacheDidUpdate plugin. Otherwise, we don't
         // need it.
         if (response.type !== 'opaque' &&
           this.plugins.has('cacheDidUpdate')) {
@@ -275,13 +275,13 @@ class RequestWrapper {
         }
 
         // Regardless of whether or not we'll end up invoking
-        // cacheDidUpdateCallbacks, wait until the cache is updated.
+        // cacheDidUpdate, wait until the cache is updated.
         const cacheRequest = cacheKey || request;
         await cache.put(cacheRequest, newResponse);
 
         if (this.plugins.has('cacheDidUpdate')) {
           for (let plugin of this.plugins.get('cacheDidUpdate')) {
-            plugin.cacheDidUpdate({
+            await plugin.cacheDidUpdate({
               cacheName: this.cacheName,
               oldResponse,
               newResponse,


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #437 

This was not fun to track down—the culprit was using `await` inside the function passed to `forEach()` not behaving like I thought. Switching to `for ... of` seems to have done the trick.

This also allows handlers that have opted-in to `waitForCache` behavior to wait until the cache expiration logic has completed before returning a response.

It adds some end-to-end tests to catch the original issue and as general hygiene.