### PR TITLE
Support for a BroadcastCacheUpdate plugin for precached() assets

### DIFF
--- a/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update-plugin.js
+++ b/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update-plugin.js
@@ -58,8 +58,9 @@ class BroadcastCacheUpdatePlugin extends BroadcastCacheUpdate {
    * @param {string} input.cacheName Name of the cache the responses belong to.
    * @param {Response} [input.oldResponse] The previous cached value, if any.
    * @param {Response} input.newResponse The new value in the cache.
+   * @param {string} input.url The cache key URL.
    */
-  cacheDidUpdate({cacheName, oldResponse, newResponse}) {
+  cacheDidUpdate({cacheName, oldResponse, newResponse, url}) {
     assert.isType({cacheName}, 'string');
     assert.isInstance({newResponse}, Response);
 
@@ -68,6 +69,7 @@ class BroadcastCacheUpdatePlugin extends BroadcastCacheUpdate {
         cacheName,
         first: oldResponse,
         second: newResponse,
+        url,
       });
     }
   }

--- a/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update.js
+++ b/packages/sw-broadcast-cache-update/src/lib/broadcast-cache-update.js
@@ -104,13 +104,14 @@ class BroadcastCacheUpdate {
    * @param {Response} input.second Another of the respones to compare.
    *        This should not be an {@link http://stackoverflow.com/questions/39109789|opaque response}.
    * @param {string} input.cacheName Name of the cache the responses belong to.
+   * @param {string} input.url The cache key URL.
    */
-  notifyIfUpdated({first, second, cacheName}) {
+  notifyIfUpdated({first, second, cacheName, url}) {
     assert.isType({cacheName}, 'string');
 
     if (
       !responsesAreSame({first, second, headersToCheck: this.headersToCheck})) {
-      broadcastUpdate({cacheName, url: second.url,
+      broadcastUpdate({cacheName, url,
         channel: this.channel, source: this.source});
     }
   }

--- a/packages/sw-broadcast-cache-update/src/lib/responses-are-same.js
+++ b/packages/sw-broadcast-cache-update/src/lib/responses-are-same.js
@@ -14,6 +14,7 @@
 */
 
 import ErrorFactory from './error-factory';
+import logHelper from '../../../../lib/log-helper.js';
 
 /**
  * Given two `Response`s, compares several header values to see if they are
@@ -42,9 +43,28 @@ import ErrorFactory from './error-factory';
  */
 function responsesAreSame({first, second, headersToCheck}={}) {
   if (!(first instanceof Response &&
-        second instanceof Response &&
-        headersToCheck instanceof Array)) {
+    second instanceof Response &&
+    headersToCheck instanceof Array)) {
     throw ErrorFactory.createError('responses-are-same-parameters-required');
+  }
+
+  const atLeastOneHeaderAvailable = headersToCheck.some((header) => {
+    return first.headers.has(header) && second.headers.has(header);
+  });
+  if (!atLeastOneHeaderAvailable) {
+    logHelper.log({
+      message: `Unable to determine whether the response has been updated
+        because none of the headers that would be checked are present.`,
+      data: {
+        'First Response': first,
+        'Second Response': second,
+        'Headers To Check': JSON.stringify(headersToCheck),
+      },
+    });
+
+    // Just return true, indicating the that responses are the same, since we
+    // can't determine otherwise.
+    return true;
   }
 
   return headersToCheck.every((header) => {

--- a/packages/sw-broadcast-cache-update/test/sw/broadcast-update.js
+++ b/packages/sw-broadcast-cache-update/test/sw/broadcast-update.js
@@ -2,7 +2,7 @@ importScripts(
   '/node_modules/mocha/mocha.js',
   '/node_modules/chai/chai.js',
   '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
-  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
+  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.js'
 );
 
 const expect = self.chai.expect;

--- a/packages/sw-broadcast-cache-update/test/sw/responses-are-same.js
+++ b/packages/sw-broadcast-cache-update/test/sw/responses-are-same.js
@@ -45,6 +45,13 @@ describe('Test of the responsesAreSame function', function() {
       first, second, headersToCheck})).to.be.true;
   });
 
+  it(`should return true when no headers exist`, function() {
+    const first = new Response('');
+    const second = new Response('');
+    expect(goog.broadcastCacheUpdate.responsesAreSame({
+      first, second, headersToCheck})).to.be.true;
+  });
+
   it(`should return false when one header matches and the other doesn't`, function() {
     const first = new Response('', {
       headers: {[firstHeaderName]: 'same', [secondHeaderName]: 'same'}});

--- a/packages/sw-lib/src/lib/sw-lib.js
+++ b/packages/sw-lib/src/lib/sw-lib.js
@@ -22,6 +22,8 @@ import {RevisionedCacheManager} from '../../../sw-precaching/src/index.js';
 import {Route} from '../../../sw-routing/src/index.js';
 import logHelper from '../../../../lib/log-helper';
 import {getDefaultCacheName} from '../../../sw-runtime-caching/src/index.js';
+import {BroadcastCacheUpdatePlugin} from
+  '../../../sw-broadcast-cache-update/src/index.js';
 
 /**
  * A high level library to make it as easy as possible to precache assets
@@ -38,9 +40,15 @@ class SWLib {
    * across cache names. Useful if you have multiple sites served over
    * localhost.
    * @param {boolean} clientsClaim To claim currently open clients set
-   * this value to true. (Default false).
+   * this value to true. (Defaults to false).
+   * @param {string} [precacheUpdatesChannel] This value will be used as the
+   * `channelName` to construct a {@link BroadcastCacheUpdate} plugin. The
+   * plugin sends a message whenever a precached URL is updated. To disable this
+   * plugin, set `precacheUpdatesChannel` to an empty string.
+   * (Defaults to `'precache-updates'`)
    */
-  constructor({cacheId, clientsClaim, handleFetch} = {}) {
+  constructor({cacheId, clientsClaim, handleFetch,
+               precacheUpdatesChannel = 'precache-updates'} = {}) {
     if (cacheId && (typeof cacheId !== 'string' || cacheId.length === 0)) {
       throw ErrorFactory.createError('bad-cache-id');
     }
@@ -48,9 +56,20 @@ class SWLib {
       throw ErrorFactory.createError('bad-clients-claim');
     }
 
+    const plugins = [];
+    if (precacheUpdatesChannel) {
+      plugins.push(new BroadcastCacheUpdatePlugin({
+        channelName: precacheUpdatesChannel,
+        source: registration && registration.scope ?
+          registration.scope :
+          location,
+      }));
+    }
+
     this._runtimeCacheName = getDefaultCacheName({cacheId});
     this._revisionedCacheManager = new RevisionedCacheManager({
       cacheId,
+      plugins,
     });
     this._strategies = new Strategies({
       cacheId,

--- a/packages/sw-lib/src/lib/sw-lib.js
+++ b/packages/sw-lib/src/lib/sw-lib.js
@@ -44,15 +44,15 @@ class SWLib {
    * @param  {String} [input.directoryIndex]  The directoryIndex will
    * check cache entries for a URLs ending with '/' to see if there is a hit
    * when appending the directoryIndex (i.e. '/index.html').
-   * @param {string} [input.precacheUpdatesChannel] This value will be used as
+   * @param {string} [input.precacheChannelName] This value will be used as
    * the `channelName` to construct a {@link BroadcastCacheUpdate} plugin. The
    * plugin sends a message whenever a precached URL is updated. To disable this
-   * plugin, set `precacheUpdatesChannel` to an empty string.
+   * plugin, set `precacheChannelName` to an empty string.
    * (Defaults to `'precache-updates'`)
    */
   constructor({cacheId, clientsClaim, handleFetch,
                directoryIndex = 'index.html',
-               precacheUpdatesChannel = 'precache-updates'} = {}) {
+               precacheChannelName = 'precache-updates'} = {}) {
     if (cacheId && (typeof cacheId !== 'string' || cacheId.length === 0)) {
       throw ErrorFactory.createError('bad-cache-id');
     }
@@ -69,9 +69,9 @@ class SWLib {
     }
 
     const plugins = [];
-    if (precacheUpdatesChannel) {
+    if (precacheChannelName) {
       plugins.push(new BroadcastCacheUpdatePlugin({
-        channelName: precacheUpdatesChannel,
+        channelName: precacheChannelName,
         source: registration && registration.scope ?
           registration.scope :
           location,

--- a/packages/sw-lib/test/sw/cache-id.js
+++ b/packages/sw-lib/test/sw/cache-id.js
@@ -43,8 +43,6 @@ describe('Cache ID', function() {
       cacheId: CACHE_ID,
     });
 
-    console.log(swlib.runtimeCacheName);
-
     swlib._revisionedCacheManager.getCacheName().indexOf(CACHE_ID).should.not.equal(-1);
     swlib.runtimeCacheName.indexOf(CACHE_ID).should.not.equal(-1);
   });

--- a/packages/sw-lib/test/sw/precache-updates-channel.js
+++ b/packages/sw-lib/test/sw/precache-updates-channel.js
@@ -14,8 +14,8 @@ mocha.setup({
   reporter: null,
 });
 
-describe('precacheUpdatesChannel parameter', function() {
-  it('should create a BroadcastCacheUpdatePlugin using the default channelName when precacheUpdatesChannel is undefined', function() {
+describe('precacheChannelName parameter', function() {
+  it('should create a BroadcastCacheUpdatePlugin using the default channelName when precacheChannelName is undefined', function() {
     const swlib = new goog.SWLib();
     const plugins = swlib._revisionedCacheManager._requestWrapper.plugins;
     expect(plugins.has('cacheDidUpdate')).to.be.true;
@@ -24,19 +24,19 @@ describe('precacheUpdatesChannel parameter', function() {
     expect(broadcastCacheUpdatePlugin.channelName).to.eql('precache-updates');
   });
 
-  it('should create a BroadcastCacheUpdatePlugin using the provided precacheUpdatesChannel as the channelName', function() {
-    const precacheUpdatesChannel = 'my-test-channel';
-    const swlib = new goog.SWLib({precacheUpdatesChannel});
+  it('should create a BroadcastCacheUpdatePlugin using the provided precacheChannelName as the channelName', function() {
+    const precacheChannelName = 'my-test-channel';
+    const swlib = new goog.SWLib({precacheChannelName});
     const plugins = swlib._revisionedCacheManager._requestWrapper.plugins;
     expect(plugins.has('cacheDidUpdate')).to.be.true;
 
     const broadcastCacheUpdatePlugin = plugins.get('cacheDidUpdate')[0];
-    expect(broadcastCacheUpdatePlugin.channelName).to.eql(precacheUpdatesChannel);
+    expect(broadcastCacheUpdatePlugin.channelName).to.eql(precacheChannelName);
   });
 
-  for (let precacheUpdatesChannel of [null, false, '']) {
-    it(`should not create a BroadcastCacheUpdatePlugin when precacheUpdatesChannel is ${precacheUpdatesChannel}`, function() {
-      const swlib = new goog.SWLib({precacheUpdatesChannel});
+  for (let precacheChannelName of [null, false, '']) {
+    it(`should not create a BroadcastCacheUpdatePlugin when precacheChannelName is ${precacheChannelName}`, function() {
+      const swlib = new goog.SWLib({precacheChannelName});
       const plugins = swlib._revisionedCacheManager._requestWrapper.plugins;
       expect(plugins.has('cacheDidUpdate')).to.be.false;
     });

--- a/packages/sw-lib/test/sw/precache-updates-channel.js
+++ b/packages/sw-lib/test/sw/precache-updates-channel.js
@@ -6,6 +6,8 @@ importScripts(
   '/packages/sw-lib/build/sw-lib.js'
 );
 
+/* global goog */
+
 const expect = self.chai.expect;
 mocha.setup({
   ui: 'bdd',

--- a/packages/sw-lib/test/sw/precache-updates-channel.js
+++ b/packages/sw-lib/test/sw/precache-updates-channel.js
@@ -1,0 +1,42 @@
+importScripts(
+  '/node_modules/mocha/mocha.js',
+  '/node_modules/chai/chai.js',
+  '/node_modules/sinon/pkg/sinon.js',
+  '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
+  '/packages/sw-lib/build/sw-lib.js'
+);
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('precacheUpdatesChannel parameter', function() {
+  it('should create a BroadcastCacheUpdatePlugin using the default channelName when precacheUpdatesChannel is undefined', function() {
+    const swlib = new goog.SWLib();
+    const plugins = swlib._revisionedCacheManager._requestWrapper.plugins;
+    expect(plugins.has('cacheDidUpdate')).to.be.true;
+
+    const broadcastCacheUpdatePlugin = plugins.get('cacheDidUpdate')[0];
+    expect(broadcastCacheUpdatePlugin.channelName).to.eql('precache-updates');
+  });
+
+  it('should create a BroadcastCacheUpdatePlugin using the provided precacheUpdatesChannel as the channelName', function() {
+    const precacheUpdatesChannel = 'my-test-channel';
+    const swlib = new goog.SWLib({precacheUpdatesChannel});
+    const plugins = swlib._revisionedCacheManager._requestWrapper.plugins;
+    expect(plugins.has('cacheDidUpdate')).to.be.true;
+
+    const broadcastCacheUpdatePlugin = plugins.get('cacheDidUpdate')[0];
+    expect(broadcastCacheUpdatePlugin.channelName).to.eql(precacheUpdatesChannel);
+  });
+
+  for (let precacheUpdatesChannel of [null, false, '']) {
+    it(`should not create a BroadcastCacheUpdatePlugin when precacheUpdatesChannel is ${precacheUpdatesChannel}`, function() {
+      const swlib = new goog.SWLib({precacheUpdatesChannel});
+      const plugins = swlib._revisionedCacheManager._requestWrapper.plugins;
+      expect(plugins.has('cacheDidUpdate')).to.be.false;
+    });
+  }
+});

--- a/packages/sw-precaching/src/lib/controllers/base-cache-manager.js
+++ b/packages/sw-precaching/src/lib/controllers/base-cache-manager.js
@@ -9,9 +9,16 @@ import {RequestWrapper} from '../../../../sw-runtime-caching/src/index';
 class BaseCacheManager {
   /**
    * Constructor for BaseCacheManager
-   * @param {String} cacheName This is the cache name to store requested assets.
+   *
+   * @param {Object} input
+   * @param {String} [input.cacheName] This is the cache name to store requested
+   * assets.
+   * @param {String} [input.cacheId] The cacheId can be used to ensure that
+   * multiple projects sharing `http://localhost` have unique cache names.
+   * @param {Array<Object>} [input.plugins] Any plugins that should be
+   * invoked by the underlying `RequestWrapper`.
    */
-  constructor({cacheName, cacheId}) {
+  constructor({cacheName, cacheId, plugins} = {}) {
     if (cacheId && (typeof cacheId !== 'string' || cacheId.length === 0)) {
       throw ErrorFactory.createError('bad-cache-id');
     }
@@ -20,6 +27,7 @@ class BaseCacheManager {
     this._requestWrapper = new RequestWrapper({
       cacheName,
       cacheId,
+      plugins,
       fetchOptions: {
         credentials: 'same-origin',
       },

--- a/packages/sw-precaching/src/lib/controllers/revisioned-cache-manager.js
+++ b/packages/sw-precaching/src/lib/controllers/revisioned-cache-manager.js
@@ -25,11 +25,13 @@ class RevisionedCacheManager extends BaseCacheManager {
    * entries.
    * @param {String} [input.cacheId] The cacheId can be used to ensure that
    * multiple projects sharing `http://localhost` have unique cache names.
+   * @param {Array<Object>} [input.plugins] Any plugins that should be
+   * invoked by the underlying `RequestWrapper`.
    */
-  constructor({cacheName, cacheId} = {}) {
-    cacheName = cacheName || defaultRevisionedCacheName;
+  constructor(input = {}) {
+    input.cacheName = input.cacheName || defaultRevisionedCacheName;
 
-    super({cacheName, cacheId});
+    super(input);
 
     this._revisionDetailsModel = new RevisionDetailsModel();
   }

--- a/packages/sw-precaching/src/lib/controllers/unrevisioned-cache-manager.js
+++ b/packages/sw-precaching/src/lib/controllers/unrevisioned-cache-manager.js
@@ -17,11 +17,15 @@ class UnrevisionedCacheManager extends BaseCacheManager {
   /**
    * Constructor for UnreivisionedCacheManager
    * @param {Object} input
-   * @param {String} [input.cacheName] Define the cache used to stash these
-   * entries.
+   * @param {String} [input.cacheName] This is the cache name to store requested
+   * assets.
+   * @param {String} [input.cacheId] The cacheId can be used to ensure that
+   * multiple projects sharing `http://localhost` have unique cache names.
+   * @param {Array<Object>} [input.plugins] Any plugins that should be
+   * invoked by the underlying `RequestWrapper`.
    */
-   constructor({cacheName, cacheId} = {}) {
-     super({cacheName, cacheId});
+   constructor(input = {}) {
+     super(input);
   }
 
   /**

--- a/packages/sw-precaching/test/sw/plugins.js
+++ b/packages/sw-precaching/test/sw/plugins.js
@@ -1,0 +1,28 @@
+importScripts('/node_modules/mocha/mocha.js');
+importScripts('/node_modules/chai/chai.js');
+importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
+importScripts('/packages/sw-precaching/build/sw-precaching.js');
+
+const expect = self.chai.expect;
+mocha.setup({
+  ui: 'bdd',
+  reporter: null,
+});
+
+describe('Test plugins Parameter', function() {
+  it('should pass the provided plugins configuration along to the RequestWrapper', function() {
+    // Register two dummy fetchDidFail plugins, and one dummy cacheWillUpdate.
+    const cacheManager = new goog.precaching.RevisionedCacheManager({
+      plugins: [{
+        fetchDidFail: () => {},
+        cacheWillUpdate: () => {},
+      }, {
+        fetchDidFail: () => {},
+      }],
+    });
+
+    expect(cacheManager._requestWrapper.plugins.size).to.eql(2);
+    expect(cacheManager._requestWrapper.plugins.get('fetchDidFail').length).to.eql(2);
+    expect(cacheManager._requestWrapper.plugins.get('cacheWillUpdate').length).to.eql(1);
+  });
+});

--- a/packages/sw-precaching/test/sw/plugins.js
+++ b/packages/sw-precaching/test/sw/plugins.js
@@ -3,6 +3,8 @@ importScripts('/node_modules/chai/chai.js');
 importScripts('/node_modules/sw-testing-helpers/build/browser/mocha-utils.js');
 importScripts('/packages/sw-precaching/build/sw-precaching.js');
 
+/* global goog */
+
 const expect = self.chai.expect;
 mocha.setup({
   ui: 'bdd',

--- a/packages/sw-runtime-caching/src/lib/request-wrapper.js
+++ b/packages/sw-runtime-caching/src/lib/request-wrapper.js
@@ -265,18 +265,18 @@ class RequestWrapper {
       // completion of this method, depending on the value of `waitOnCache`.
       cachingComplete = this.getCache().then(async (cache) => {
         let oldResponse;
+        const cacheRequest = cacheKey || request;
 
         // Only bother getting the old response if the new response isn't opaque
         // and there's at least one cacheDidUpdate plugin. Otherwise, we don't
         // need it.
         if (response.type !== 'opaque' &&
           this.plugins.has('cacheDidUpdate')) {
-          oldResponse = await this.match({request});
+          oldResponse = await this.match({request: cacheRequest});
         }
 
         // Regardless of whether or not we'll end up invoking
         // cacheDidUpdate, wait until the cache is updated.
-        const cacheRequest = cacheKey || request;
         await cache.put(cacheRequest, newResponse);
 
         if (this.plugins.has('cacheDidUpdate')) {
@@ -285,7 +285,8 @@ class RequestWrapper {
               cacheName: this.cacheName,
               oldResponse,
               newResponse,
-              url: request.url,
+              // cacheRequest may be a Request with a url property, or a string.
+              url: ('url' in cacheRequest) ? cacheRequest.url : cacheRequest,
             });
           }
         }


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #309, fixes #441

This adds support for a `BroadcastCacheUpdates` plugin that's enabled by default in `SWLib`, and announces when previously cached resources are updated.

I had to account for the fact that `precache()` might append a cache-busting URL parameter when retrieving responses from the network, so there needed to be a bit of massaging via the `cacheKey` parameter inside of `RequestWrapper.fetchAndCache()` to ensure that the proper responses were compared, and the proper URL reported to `BroadcastCacheUpdates`.