### PR TITLE
Build/linting fixes for sw-build-webpack-plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ node_js:
 env:
   - PROJECT="sw-background-sync-queue"
   - PROJECT="sw-broadcast-cache-update"
-  - PROJECT="sw-cache-expiration"
   - PROJECT="sw-build"
+  - PROJECT="sw-build-webpack-plugin"
+  - PROJECT="sw-cache-expiration"
   - PROJECT="sw-cli"
   - PROJECT="sw-lib"
   - PROJECT="sw-offline-google-analytics"

--- a/packages/sw-build-webpack-plugin/build.js
+++ b/packages/sw-build-webpack-plugin/build.js
@@ -1,0 +1,35 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+const fsExtra = require('fs-extra');
+const path = require('path');
+
+const copyPath = (from, to) => {
+  return new Promise((resolve, reject) => {
+    fsExtra.copy(from, to, (err) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    });
+  });
+};
+
+module.exports = () => {
+  return copyPath(
+    path.join(__dirname, 'index.js'),
+    path.join(__dirname, 'build/index.js')
+  );
+};

--- a/packages/sw-build-webpack-plugin/index.js
+++ b/packages/sw-build-webpack-plugin/index.js
@@ -1,5 +1,4 @@
-const swBuild = require('../sw-build/src/');
-const path = require('path');
+const swBuild = require('../sw-build/src/index');
 
 /**
  * Use the instance of this in the plugins array of the webpack config.
@@ -31,6 +30,13 @@ class SwBuildWebpackPlugin {
 	constructor(config) {
 		this._config = config || {};
 	}
+
+  /**
+   * @private
+   * @param {Object} compilation The [compilation](https://github.com/webpack/docs/wiki/how-to-write-a-plugin#accessing-the-compilation),
+   * passed from Webpack to this plugin.
+   * @return {Object} The configuration for a given compilation.
+   */
 	getConfig(compilation) {
 		let config = this._config;
 
@@ -44,7 +50,6 @@ class SwBuildWebpackPlugin {
 	}
 
 	/**
-	 *
 	 * @param {Object} [compiler] default compiler object passed from webpack
 	 *
 	 * @memberOf SwBuildWebpackPlugin

--- a/packages/sw-build-webpack-plugin/index.js
+++ b/packages/sw-build-webpack-plugin/index.js
@@ -1,4 +1,4 @@
-const swBuild = require('../sw-build/src/index');
+const swBuild = require('sw-build');
 
 /**
  * Use the instance of this in the plugins array of the webpack config.

--- a/packages/sw-build-webpack-plugin/package.json
+++ b/packages/sw-build-webpack-plugin/package.json
@@ -20,6 +20,9 @@
   "engines": {
     "node": ">=4.0.0"
   },
+  "dependencies": {
+    "sw-build": "0.0.18"
+  },
   "author": "Google's Web DevRel Team",
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",

--- a/packages/sw-build-webpack-plugin/test/.eslintrc
+++ b/packages/sw-build-webpack-plugin/test/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "max-len": 0,
+    "require-jsdoc": 0
+  },
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "goog": true,
+    "expect": true,
+    "sinon": true
+  }
+}

--- a/packages/sw-build-webpack-plugin/test/node/test.js
+++ b/packages/sw-build-webpack-plugin/test/node/test.js
@@ -27,7 +27,6 @@ sinon.stub(webpackCompilation.compiler, 'plugin', (event, callback)=> {
 });
 
 describe('Tests for webpack plugin', function() {
-
 	beforeEach(()=>{
 		// Build a proxy sw-build
 		proxySwBuild = {
@@ -37,13 +36,13 @@ describe('Tests for webpack plugin', function() {
 
 		// Generate stub methods
 		sinon.stub(proxySwBuild, 'generateSW', function() {
-			return new Promise((resolve, reject) => {
+			return new Promise((resolve) => {
 				resolve();
 			});
 		});
 
 		sinon.stub(proxySwBuild, 'injectManifest', function() {
-			return new Promise((resolve, reject) => {
+			return new Promise((resolve) => {
 				resolve();
 			});
 		});
@@ -52,7 +51,7 @@ describe('Tests for webpack plugin', function() {
 		SwWebpackPlugin = proxyquire('../../', {
 			'../sw-build/src/': proxySwBuild,
 		});
-	})
+	});
 
 	it('should mutate config accordin to webpack defaults', () => {
 		sinon.stub(webpackCompilation.mainTemplate, 'getPublicPath', ()=>{


### PR DESCRIPTION
R: @prateekbh @addyosmani @gauntface

There are some linting errors in `sw-build-wepback-plugin` that prevent the `gulp test` portion of the `npm run publish-release` process from completing. This fixes those errors.

(I'm not sure why those errors weren't flagged in Travis CI to begin with?)
