### PR TITLE
Glob directory

### DIFF
--- a/packages/sw-build-webpack-plugin/index.js
+++ b/packages/sw-build-webpack-plugin/index.js
@@ -57,7 +57,7 @@ class SwBuildWebpackPlugin {
 	apply(compiler) {
 		compiler.plugin('after-emit', (compilation, callback) => {
 			const config = this.getConfig(compilation);
-			if (config.swFile) {
+			if (config.swPath) {
 				swBuild.injectManifest(config)
 					.then(() => callback())
 					.catch((e) => callback(e));

--- a/packages/sw-build-webpack-plugin/test/node/test.js
+++ b/packages/sw-build-webpack-plugin/test/node/test.js
@@ -71,7 +71,7 @@ describe('Tests for webpack plugin', function() {
 			CUSTOM_ROOT_DIRECTORY);
 	});
 
-	it('should call generateSw when swFile is not given', () => {
+	it('should call generateSw when swPath is not given', () => {
 		let swWebpackPlugin = new SwWebpackPlugin({});
 		swWebpackPlugin.apply(webpackCompilation.compiler);
 		// Plugin is being called once
@@ -86,9 +86,9 @@ describe('Tests for webpack plugin', function() {
 		assert.isTrue(proxySwBuild.injectManifest.notCalled);
 	});
 
-	it('should call injectManifest when swFile is given', () => {
+	it('should call injectManifest when swPath is given', () => {
 		let swWebpackPlugin = new SwWebpackPlugin({
-			swFile: './sw.js',
+			swPath: './sw.js',
 		});
 		swWebpackPlugin.apply(webpackCompilation.compiler);
 		// Plugin is being called once

--- a/packages/sw-build/src/index.js
+++ b/packages/sw-build/src/index.js
@@ -25,10 +25,10 @@ const injectManifest = require('./lib/inject-manifest');
  * const swBuild = require('sw-build');
  *
  * swBuild.generateFileManifest({
- *   rootDirectory: './build/',
- *   dest: './build/scripts/manifest.js',
+ *   globDirectory: './build/',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['service-worker.js','admin.html'],
+ *   dest: './build/scripts/manifest.js',
  *   templatedUrls: {
  *     '/shell': ['shell.hbs', 'main.css', 'shell.css'],
  *   },
@@ -41,7 +41,7 @@ const injectManifest = require('./lib/inject-manifest');
  * const swBuild = require('sw-build');
  *
  * swBuild.getFileManifestEntries({
- *   rootDirectory: './build/',
+ *   globDirectory: './build/',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['service-worker.js','admin.html'],
  *   templatedUrls: {
@@ -56,10 +56,10 @@ const injectManifest = require('./lib/inject-manifest');
  * const swBuild = require('sw-build');
  *
  * swBuild.generateSW({
- *   rootDirectory: './build/',
- *   dest: './build/sw.js',
+ *   globDirectory: './build/',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['service-worker.js','admin.html'],
+ *   dest: './build/sw.js',
  *   templatedUrls: {
  *     '/shell': ['shell.hbs', 'main.css', 'shell.css'],
  *   },

--- a/packages/sw-build/src/lib/errors.js
+++ b/packages/sw-build/src/lib/errors.js
@@ -29,7 +29,7 @@ module.exports = {
     'not be copied over to your new site.',
   'invalid-generate-sw-input': 'The input to generateSW() must be an ' +
     'object',
-  'invalid-root-directory': 'The supplied rootDirectory must be ' +
+  'invalid-glob-directory': 'The supplied globDirectory must be ' +
     'a path as a string.',
   'invalid-exclude-files': 'The excluded files should be an array of strings.',
   'invalid-get-manifest-entries-input': 'The input to ' +

--- a/packages/sw-build/src/lib/generate-file-manifest.js
+++ b/packages/sw-build/src/lib/generate-file-manifest.js
@@ -9,7 +9,7 @@ const errors = require('./errors');
  *
  * swBuild.generateFileManifest({
  *   dest: './build/manifest.js'
- *   rootDirectory: './build/',
+ *   globDirectory: './build/',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['admin.html'],
  *   format: 'iife', // alternatively, use 'es'
@@ -23,7 +23,7 @@ const errors = require('./errors');
  * @param {Object} input
  * @param {String} input.dest The name and path you wish to write your
  * manifest file to.
- * @param {String} input.rootDirectory The root of the files you wish to
+ * @param {String} input.globDirectory The root of the files you wish to
  * be cached. This will also be the directory the service worker and library
  * files are written to.
  * @param {Array<String>} input.staticFileGlobs Patterns to glob for when

--- a/packages/sw-build/src/lib/generate-sw.js
+++ b/packages/sw-build/src/lib/generate-sw.js
@@ -9,7 +9,7 @@ const errors = require('./errors');
  * const swBuild = require('sw-build');
  *
  * swBuild.generateSW({
- *   rootDirectory: './build/',
+ *   globDirectory: './build/',
  *   dest: './build/sw.js',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['admin.html'],
@@ -24,7 +24,7 @@ const errors = require('./errors');
  * This method will generate a working service worker with an inlined
  * file manifest.
  * @param {Object} input
- * @param {String} input.rootDirectory The root of the files you wish to
+ * @param {String} input.globDirectory The root of the files you wish to
  * be cached. This will also be the directory the service worker and library
  * files are written to.
  * @param {Array<String>} input.staticFileGlobs Patterns to glob for when
@@ -65,10 +65,10 @@ const generateSW = function(input) {
       new Error(errors['invalid-glob-ignores']));
   }
 
-  if (typeof input.rootDirectory !== 'string' ||
-    input.rootDirectory.length === 0) {
+  if (typeof input.globDirectory !== 'string' ||
+    input.globDirectory.length === 0) {
     return Promise.reject(
-      new Error(errors['invalid-root-directory']));
+      new Error(errors['invalid-glob-directory']));
   }
 
   if (typeof input.dest !== 'string' || input.dest.length === 0) {
@@ -76,23 +76,24 @@ const generateSW = function(input) {
       new Error(errors['invalid-dest']));
   }
 
-  const rootDirectory = input.rootDirectory;
+  const globDirectory = input.globDirectory;
   const staticFileGlobs = input.staticFileGlobs;
   const globIgnores = input.globIgnores ? input.globIgnores : [];
   const dest = input.dest;
   const templatedUrls = input.templatedUrls;
 
   let swlibPath;
-  return copySWLib(rootDirectory)
+  let destDirectory = path.dirname(dest);
+  return copySWLib(destDirectory)
   .then((libPath) => {
     swlibPath = libPath;
-    globIgnores.push(path.relative(rootDirectory, swlibPath));
+    globIgnores.push(path.relative(destDirectory, swlibPath));
   })
   .then(() => {
     return getFileManifestEntries({
       staticFileGlobs,
       globIgnores,
-      rootDirectory,
+      globDirectory,
       templatedUrls,
     });
   })
@@ -101,7 +102,7 @@ const generateSW = function(input) {
       dest,
       manifestEntries,
       swlibPath,
-      rootDirectory,
+      globDirectory,
       input
     );
   });

--- a/packages/sw-build/src/lib/generate-sw.js
+++ b/packages/sw-build/src/lib/generate-sw.js
@@ -86,8 +86,10 @@ const generateSW = function(input) {
   let destDirectory = path.dirname(dest);
   return copySWLib(destDirectory)
   .then((libPath) => {
-    swlibPath = libPath;
-    globIgnores.push(path.relative(destDirectory, swlibPath));
+    // If sw file is in build/sw.js, the swlib file will be build/swlib.***.js
+    // So the sw.js file should import swlib.***.js (i.e. not include build/).
+    swlibPath = path.relative(destDirectory, libPath);
+    globIgnores.push(swlibPath);
   })
   .then(() => {
     return getFileManifestEntries({

--- a/packages/sw-build/src/lib/get-file-manifest-entries.js
+++ b/packages/sw-build/src/lib/get-file-manifest-entries.js
@@ -22,7 +22,7 @@ const getStringDetails = require('./utils/get-string-details');
  * include in the file entries.
  * @param {Array<String>} [input.globIgnores] Patterns used to exclude files
  * from the file entries.
- * @param {String} input.rootDirectory The directory run the glob patterns over.
+ * @param {String} input.globDirectory The directory run the glob patterns over.
  * @param {Object<String,Array|String>} [input.templatedUrls]
  * If a URL is rendered/templated on the server, its contents may not depend on
  * a single file. This maps URLs to a list of file names, or to a string
@@ -38,12 +38,12 @@ const getFileManifestEntries = (input) => {
 
   const staticFileGlobs = input.staticFileGlobs;
   const globIgnores = input.globIgnores ? input.globIgnores : [];
-  const rootDirectory = input.rootDirectory;
+  const globDirectory = input.globDirectory;
   const templatedUrls = input.templatedUrls;
 
-  if (typeof rootDirectory !== 'string' || rootDirectory.length === 0) {
+  if (typeof globDirectory !== 'string' || globDirectory.length === 0) {
     return Promise.reject(
-      new Error(errors['invalid-root-directory']));
+      new Error(errors['invalid-glob-directory']));
   }
 
   if (!staticFileGlobs || !Array.isArray(staticFileGlobs)) {
@@ -71,7 +71,7 @@ const getFileManifestEntries = (input) => {
 
   const fileDetails = staticFileGlobs.reduce((accumulated, globPattern) => {
     const globbedFileDetails = getFileDetails(
-      rootDirectory, globPattern, globIgnores);
+      globDirectory, globPattern, globIgnores);
     globbedFileDetails.forEach((fileDetails) => {
       if (fileSet.has(fileDetails.file)) {
         return;
@@ -99,7 +99,7 @@ const getFileManifestEntries = (input) => {
       if (Array.isArray(dependencies)) {
         const dependencyDetails = dependencies.reduce((previous, pattern) => {
           const globbedFileDetails = getFileDetails(
-            rootDirectory, pattern, globIgnores);
+            globDirectory, pattern, globIgnores);
           return previous.concat(globbedFileDetails);
         }, []);
         fileDetails.push(getCompositeDetails(url, dependencyDetails));

--- a/packages/sw-build/src/lib/inject-manifest.js
+++ b/packages/sw-build/src/lib/inject-manifest.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
-const path = require('path');
 const mkdirp = require('mkdirp');
+const path = require('path');
 
 const getFileManifestEntries = require('./get-file-manifest-entries');
 const errors = require('./errors');
@@ -11,11 +11,11 @@ const errors = require('./errors');
  * const swBuild = require('sw-build');
  *
  * swBuild.injectManifest({
- *   dest: './build/'
  *   globDirectory: './build/',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['admin.html'],
- *   swFile: 'sw.js'
+ *   swPath: './src/sw.js',
+ *   dest: './build/sw.js',
  * })
  * .then(() => {
  *   console.log('Build Manifest generated.');
@@ -39,7 +39,7 @@ const errors = require('./errors');
  * If a URL is rendered/templated on the server, its contents may not depend on
  * a single file. This maps URLs to a list of file names, or to a string
  * value, that uniquely determines each URL's contents.
- * @param {String} input.swFile File name for service worker file to read in
+ * @param {String} input.swPath File name for service worker file to read in
  * and alter.
  * @return {Promise} Resolves once the service worker has been generated
  * with a precache list.
@@ -56,8 +56,7 @@ const injectManifest = (input) => {
 
   return getFileManifestEntries(input)
   .then((manifestEntries) => {
-    let swFileContents = fs.readFileSync(
-      path.join(input.globDirectory, input.swFile), 'utf8');
+    let swFileContents = fs.readFileSync(input.swPath, 'utf8');
     const injectionResults = swFileContents.match(injectionPointRegex);
     if (!injectionResults) {
       throw new Error(errors['injection-point-not-found']);
@@ -72,7 +71,7 @@ const injectManifest = (input) => {
       .replace(injectionPointRegex, `$1${entriesString}$2`);
 
     return new Promise((resolve, reject) => {
-      mkdirp(input.dest, (err) => {
+      mkdirp(path.dirname(input.dest), (err) => {
         if (err) {
           return reject(
             new Error(
@@ -85,7 +84,7 @@ const injectManifest = (input) => {
       });
     })
     .then(() => {
-      fs.writeFileSync(path.join(input.dest, input.swFile), swFileContents);
+      fs.writeFileSync(input.dest, swFileContents);
     });
   });
 };

--- a/packages/sw-build/src/lib/inject-manifest.js
+++ b/packages/sw-build/src/lib/inject-manifest.js
@@ -12,7 +12,7 @@ const errors = require('./errors');
  *
  * swBuild.injectManifest({
  *   dest: './build/'
- *   rootDirectory: './build/',
+ *   globDirectory: './build/',
  *   staticFileGlobs: ['**\/*.{html,js,css}'],
  *   globIgnores: ['admin.html'],
  *   swFile: 'sw.js'
@@ -28,7 +28,7 @@ const errors = require('./errors');
  * @param {Object} input
  * @param {String} input.dest The name and path you wish to write your
  * manifest file to.
- * @param {String} input.rootDirectory The root of the files you wish to
+ * @param {String} input.globDirectory The root of the files you wish to
  * be cached. This will also be the directory the service worker and library
  * files are written to.
  * @param {Array<String>} input.staticFileGlobs Patterns to glob for when
@@ -57,7 +57,7 @@ const injectManifest = (input) => {
   return getFileManifestEntries(input)
   .then((manifestEntries) => {
     let swFileContents = fs.readFileSync(
-      path.join(input.rootDirectory, input.swFile), 'utf8');
+      path.join(input.globDirectory, input.swFile), 'utf8');
     const injectionResults = swFileContents.match(injectionPointRegex);
     if (!injectionResults) {
       throw new Error(errors['injection-point-not-found']);

--- a/packages/sw-build/src/lib/utils/copy-sw-lib.js
+++ b/packages/sw-build/src/lib/utils/copy-sw-lib.js
@@ -1,15 +1,16 @@
 const path = require('path');
 const fs = require('fs');
+const mkdirp = require('mkdirp');
 
 const errors = require('../errors');
 
-module.exports = (rootDirectory) => {
+module.exports = (outputDirectory) => {
   const swlibModuleBuildPath = path.dirname(require.resolve('sw-lib'));
   const swlibPkg = require(
     path.join(swlibModuleBuildPath, '..', 'package.json')
   );
 
-  const swlibOutputPath = path.join(rootDirectory,
+  const swlibOutputPath = path.join(outputDirectory,
     `sw-lib.v${swlibPkg.version}.min.js`);
   return new Promise((resolve) => {
     fs.unlink(swlibOutputPath, (err) => {
@@ -19,6 +20,8 @@ module.exports = (rootDirectory) => {
   .then(() => {
     return new Promise((resolve, reject) => {
       const swlibBuiltPath = path.join(swlibModuleBuildPath, 'sw-lib.min.js');
+
+      mkdirp.sync(outputDirectory);
 
       const stream = fs.createReadStream(swlibBuiltPath)
         .pipe(fs.createWriteStream(swlibOutputPath));

--- a/packages/sw-build/src/lib/utils/get-file-details.js
+++ b/packages/sw-build/src/lib/utils/get-file-details.js
@@ -5,11 +5,11 @@ const getFileSize = require('./get-file-size');
 const getFileHash = require('./get-file-hash');
 const errors = require('../errors');
 
-module.exports = (rootDirectory, globPattern, globIgnores) => {
+module.exports = (globDirectory, globPattern, globIgnores) => {
   let globbedFiles;
   try {
     globbedFiles = glob.sync(globPattern, {
-      cwd: rootDirectory,
+      cwd: globDirectory,
       ignore: globIgnores,
     });
   } catch (err) {
@@ -17,7 +17,7 @@ module.exports = (rootDirectory, globPattern, globIgnores) => {
   }
 
   const fileDetails = globbedFiles.map((file) => {
-    const fullPath = path.join(rootDirectory, file);
+    const fullPath = path.join(globDirectory, file);
     const fileSize = getFileSize(fullPath);
     if (fileSize === null) {
       return null;
@@ -25,7 +25,7 @@ module.exports = (rootDirectory, globPattern, globIgnores) => {
 
     const fileHash = getFileHash(fullPath);
     return {
-      file: `${path.relative(rootDirectory, fullPath)}`,
+      file: `${path.relative(globDirectory, fullPath)}`,
       hash: fileHash,
       size: fileSize,
     };

--- a/packages/sw-build/test/node/generate-file-manifest.js
+++ b/packages/sw-build/test/node/generate-file-manifest.js
@@ -5,10 +5,10 @@ const errors = require('../../src/lib/errors');
 
 describe('Test generateFileManifest', function() {
   const EXAMPLE_INPUT = {
+    globDirectory: '.',
     staticFileGlobs: ['./**/*.{html,css}'],
     globIgnores: [],
     dest: './manifest.js',
-    rootDirectory: '.',
   };
 
   it('should be able to handle bad input', function() {
@@ -47,13 +47,13 @@ describe('Test generateFileManifest', function() {
     }];
     const generateFileManifest = proxyquire(
       '../../src/lib/generate-file-manifest.js', {
-        './get-file-manifest-entries': ({rootDirectory, staticFileGlobs, globIgnores}) => {
+        './get-file-manifest-entries': ({globDirectory, staticFileGlobs, globIgnores}) => {
           if (globIgnores !== EXAMPLE_INPUT.globIgnores) {
             throw new Error('Invalid glob ignores value.');
           }
 
-          if (rootDirectory !== EXAMPLE_INPUT.rootDirectory) {
-            throw new Error('Invalid rootDirectory value.');
+          if (globDirectory !== EXAMPLE_INPUT.globDirectory) {
+            throw new Error('Invalid globDirectory value.');
           }
 
           if (staticFileGlobs !== EXAMPLE_INPUT.staticFileGlobs) {

--- a/packages/sw-build/test/node/generate-file-manifest.js
+++ b/packages/sw-build/test/node/generate-file-manifest.js
@@ -5,10 +5,10 @@ const errors = require('../../src/lib/errors');
 
 describe('Test generateFileManifest', function() {
   const EXAMPLE_INPUT = {
-    globDirectory: '.',
+    globDirectory: 'src/',
     staticFileGlobs: ['./**/*.{html,css}'],
     globIgnores: [],
-    dest: './manifest.js',
+    dest: './build/manifest.js',
   };
 
   it('should be able to handle bad input', function() {

--- a/packages/sw-build/test/node/generate-sw-e2e.js
+++ b/packages/sw-build/test/node/generate-sw-e2e.js
@@ -44,7 +44,7 @@ describe('Generate SW End-to-End Tests', function() {
       path.join(__dirname, '..', '..', '..', 'sw-cli', 'test', 'static', 'example-project-1'),
       tmpDirectory);
 
-    const swName = `${Date.now()}-sw.js`;
+    const dest = `build/${Date.now()}-sw.js`;
     const modifyUrlPrefix = {
       '/': '/example-prefix/',
     };
@@ -52,14 +52,14 @@ describe('Generate SW End-to-End Tests', function() {
     return validator.performTest(() => {
       return swBuild.generateSW({
         globDirectory: tmpDirectory,
-        dest: swName,
+        dest,
         staticFileGlobs: [`**\/*.{${FILE_EXTENSIONS.join(',')}}`],
         cacheId: 'example-cache-id',
         modifyUrlPrefix,
       });
     }, {
       exampleProject: tmpDirectory,
-      swName,
+      dest,
       fileExtensions: FILE_EXTENSIONS,
       baseTestUrl,
       modifyUrlPrefix,

--- a/packages/sw-build/test/node/generate-sw-e2e.js
+++ b/packages/sw-build/test/node/generate-sw-e2e.js
@@ -51,7 +51,7 @@ describe('Generate SW End-to-End Tests', function() {
     const swBuild = require('../../build/index.js');
     return validator.performTest(() => {
       return swBuild.generateSW({
-        rootDirectory: tmpDirectory,
+        globDirectory: tmpDirectory,
         dest: swName,
         staticFileGlobs: [`**\/*.{${FILE_EXTENSIONS.join(',')}}`],
         cacheId: 'example-cache-id',

--- a/packages/sw-build/test/node/generate-sw.js
+++ b/packages/sw-build/test/node/generate-sw.js
@@ -12,7 +12,7 @@ describe('Test generateSW()', function() {
     globIgnores: [
       '!node_modules/',
     ],
-    dest: 'sw.js',
+    dest: 'build/sw.js',
   };
 
   let generateSW;
@@ -187,9 +187,9 @@ describe('Test generateSW()', function() {
     args.globDirectory = '.';
 
     generateSW = proxyquire('../../src/lib/generate-sw', {
-      './utils/copy-sw-lib': (globDirectory) => {
-        if (globDirectory === '.') {
-          return Promise.resolve(path.join(globDirectory, 'sw-lib.v0.0.0.js'));
+      './utils/copy-sw-lib': (copySWLibPath) => {
+        if (copySWLibPath === path.dirname(EXAMPLE_INPUT.dest)) {
+          return Promise.resolve(path.join(copySWLibPath, 'sw-lib.v0.0.0.js'));
         }
         return Promise.reject(new Error('Inject Error - copy-sw-lib'));
       },
@@ -236,10 +236,4 @@ describe('Test generateSW()', function() {
     let args = Object.assign({}, EXAMPLE_INPUT);
     return generateSW(args);
   });
-
-  // fileExtensionsToCache - single item array
-  // fileExtensionsToCache - multiple item with multiple dots
-
-  // swName - multiple dots in name
-  // swName - nested path
 });

--- a/packages/sw-build/test/node/generate-sw.js
+++ b/packages/sw-build/test/node/generate-sw.js
@@ -223,7 +223,7 @@ describe('Test generateSW()', function() {
         if (swPath !== EXAMPLE_INPUT.dest) {
           throw new Error(`Service worker path is an unexpected value: ${swPath}`);
         }
-        if (swlibPath !== path.join(path.dirname(EXAMPLE_INPUT.dest), 'sw-lib.v0.0.0.js')) {
+        if (swlibPath !== 'sw-lib.v0.0.0.js') {
           throw new Error(`SW-Lib path is an unexpected value: ${swlibPath}`);
         }
         if (globDirectory !== EXAMPLE_INPUT.globDirectory) {

--- a/packages/sw-build/test/node/generate-sw.js
+++ b/packages/sw-build/test/node/generate-sw.js
@@ -5,7 +5,7 @@ const errors = require('../../src/lib/errors');
 
 describe('Test generateSW()', function() {
   const EXAMPLE_INPUT = {
-    rootDirectory: './valid-root',
+    globDirectory: './valid-root',
     staticFileGlobs: [
       '**/*.{css,js,html}',
     ],
@@ -18,9 +18,9 @@ describe('Test generateSW()', function() {
   let generateSW;
   beforeEach(function() {
     generateSW = proxyquire('../../src/lib/generate-sw', {
-      './utils/copy-sw-lib': (rootDirectory) => {
-        if (rootDirectory === EXAMPLE_INPUT.rootDirectory) {
-          return Promise.resolve(path.join(rootDirectory, 'sw-lib.v0.0.0.js'));
+      './utils/copy-sw-lib': (swlibPath) => {
+        if (swlibPath === path.dirname(EXAMPLE_INPUT.dest)) {
+          return Promise.resolve(path.join(swlibPath, 'sw-lib.v0.0.0.js'));
         }
         return Promise.reject(new Error('Inject Error - copy-sw-lib'));
       },
@@ -52,8 +52,8 @@ describe('Test generateSW()', function() {
     }, Promise.resolve());
   });
 
-  // rootDirectory - non string - undefined, null, array, boolean,  object
-  it('should be able to handle a bad rootDirectory iput', function() {
+  // globDirectory - non string - undefined, null, array, boolean,  object
+  it('should be able to handle a bad globDirectory iput', function() {
     const badInput = [
       undefined,
       null,
@@ -65,13 +65,13 @@ describe('Test generateSW()', function() {
     return badInput.reduce((promiseChain, input) => {
       return promiseChain.then(() => {
         let args = Object.assign({}, EXAMPLE_INPUT);
-        args.rootDirectory = input;
+        args.globDirectory = input;
         return generateSW(args)
         .then(() => {
           throw new Error('Expected to throw error.');
         })
         .catch((err) => {
-          if (err.message !== errors['invalid-root-directory']) {
+          if (err.message !== errors['invalid-glob-directory']) {
             throw new Error('Unexpected error: ' + err.message);
           }
         });
@@ -181,27 +181,27 @@ describe('Test generateSW()', function() {
 
   // Success.........................................................
 
-  // rootDirectory - dot
+  // globDirectory - dot
   it('should be able to write service worker to current directory', function() {
     let args = Object.assign({}, EXAMPLE_INPUT);
-    args.rootDirectory = '.';
+    args.globDirectory = '.';
 
     generateSW = proxyquire('../../src/lib/generate-sw', {
-      './utils/copy-sw-lib': (rootDirectory) => {
-        if (rootDirectory === '.') {
-          return Promise.resolve(path.join(rootDirectory, 'sw-lib.v0.0.0.js'));
+      './utils/copy-sw-lib': (globDirectory) => {
+        if (globDirectory === '.') {
+          return Promise.resolve(path.join(globDirectory, 'sw-lib.v0.0.0.js'));
         }
         return Promise.reject(new Error('Inject Error - copy-sw-lib'));
       },
-      './write-sw': (swPath, manifestEntries, swlibPath, rootDirectory) => {
+      './write-sw': (swPath, manifestEntries, swlibPath, globDirectory) => {
         if (swPath !== EXAMPLE_INPUT.dest) {
           throw new Error(`Service worker path is an unexpected value: ${swPath}`);
         }
         if (swlibPath !== 'sw-lib.v0.0.0.js') {
           throw new Error(`SW-Lib path is an unexpected value: ${swlibPath}`);
         }
-        if (rootDirectory !== '.') {
-          throw new Error(`rootDirectory is an unexpected value: ${rootDirectory}`);
+        if (globDirectory !== '.') {
+          throw new Error(`globDirectory is an unexpected value: ${globDirectory}`);
         }
         return Promise.resolve();
       },
@@ -210,24 +210,24 @@ describe('Test generateSW()', function() {
     return generateSW(args);
   });
 
-  // rootDirectory - valid nested folder
+  // globDirectory - valid nested folder
   it('should be able to write service worker to the a directory', function() {
     generateSW = proxyquire('../../src/lib/generate-sw', {
-      './utils/copy-sw-lib': (rootDirectory) => {
-        if (rootDirectory === EXAMPLE_INPUT.rootDirectory) {
-          return Promise.resolve(path.join(rootDirectory, 'sw-lib.v0.0.0.js'));
+      './utils/copy-sw-lib': (swlibPath) => {
+        if (swlibPath === path.dirname(EXAMPLE_INPUT.dest)) {
+          return Promise.resolve(path.join(swlibPath, 'sw-lib.v0.0.0.js'));
         }
         return Promise.reject(new Error('Inject Error - copy-sw-lib'));
       },
-      './write-sw': (swPath, manifestEntries, swlibPath, rootDirectory) => {
+      './write-sw': (swPath, manifestEntries, swlibPath, globDirectory) => {
         if (swPath !== EXAMPLE_INPUT.dest) {
           throw new Error(`Service worker path is an unexpected value: ${swPath}`);
         }
-        if (swlibPath !== path.join(EXAMPLE_INPUT.rootDirectory, 'sw-lib.v0.0.0.js')) {
+        if (swlibPath !== path.join(path.dirname(EXAMPLE_INPUT.dest), 'sw-lib.v0.0.0.js')) {
           throw new Error(`SW-Lib path is an unexpected value: ${swlibPath}`);
         }
-        if (rootDirectory !== EXAMPLE_INPUT.rootDirectory) {
-          throw new Error(`rootDirectory is an unexpected value: ${rootDirectory}`);
+        if (globDirectory !== EXAMPLE_INPUT.globDirectory) {
+          throw new Error(`globDirectory is an unexpected value: ${globDirectory}`);
         }
         return Promise.resolve();
       },

--- a/packages/sw-build/test/node/get-file-manifest-entries.js
+++ b/packages/sw-build/test/node/get-file-manifest-entries.js
@@ -9,7 +9,7 @@ describe('Test getFileManifestEntries', function() {
   const EXAMPLE_INPUT = {
     staticFileGlobs: ['./**/*.{html,css}'],
     globIgnores: [],
-    rootDirectory: '.',
+    globDirectory: '.',
   };
 
   it('should be able to handle bad input', function() {
@@ -33,7 +33,7 @@ describe('Test getFileManifestEntries', function() {
     });
   });
 
-  it('should detect bad rootDirectory', function() {
+  it('should detect bad globDirectory', function() {
     const badInput = [
       undefined,
       null,
@@ -45,13 +45,13 @@ describe('Test getFileManifestEntries', function() {
     return badInput.reduce((promiseChain, input) => {
       return promiseChain.then(() => {
         let args = Object.assign({}, EXAMPLE_INPUT);
-        args.rootDirectory = input;
+        args.globDirectory = input;
         return swBuild.getFileManifestEntries(args)
         .then(() => {
           throw new Error('Expected to throw error.');
         })
         .catch((err) => {
-          if (err.message !== errors['invalid-root-directory']) {
+          if (err.message !== errors['invalid-glob-directory']) {
             throw new Error('Unexpected error: ' + err.message);
           }
         });
@@ -89,7 +89,7 @@ describe('Test getFileManifestEntries', function() {
       staticFileGlobs: [
         '**/*.{html,js,css}',
       ],
-      rootDirectory: path.join(__dirname, '..', '..', '..',
+      globDirectory: path.join(__dirname, '..', '..', '..',
         'sw-cli', 'test', 'static', 'example-project-1'),
     };
 
@@ -121,7 +121,7 @@ describe('Test getFileManifestEntries', function() {
       staticFileGlobs: [
         '**/*.{html,js,css}',
       ],
-      rootDirectory: path.join(__dirname, '..', '..', '..',
+      globDirectory: path.join(__dirname, '..', '..', '..',
         'sw-cli', 'test', 'static', 'example-project-1'),
       modifyUrlPrefix: {
         '/styles': '/static/styles',

--- a/packages/sw-build/test/node/get-file-manifest-entries.js
+++ b/packages/sw-build/test/node/get-file-manifest-entries.js
@@ -98,7 +98,7 @@ describe('Test getFileManifestEntries', function() {
       output.should.deep.equal([
         {
           url: '/index.html',
-          revision: '218c18c2a07f6fbe326de4c9b0676164',
+          revision: '24abd5daf6d87c25f40c2b74ee3fbe93',
         }, {
           url: '/page-1.html',
           revision: '544658ab25ee8762dc241e8b1c5ed96d',
@@ -134,7 +134,7 @@ describe('Test getFileManifestEntries', function() {
       output.should.deep.equal([
         {
           url: '/index.html',
-          revision: '218c18c2a07f6fbe326de4c9b0676164',
+          revision: '24abd5daf6d87c25f40c2b74ee3fbe93',
         }, {
           url: '/pages/page-1.html',
           revision: '544658ab25ee8762dc241e8b1c5ed96d',

--- a/packages/sw-build/test/node/injection-manifest.js
+++ b/packages/sw-build/test/node/injection-manifest.js
@@ -35,17 +35,17 @@ describe('Test Injection Manifest', function() {
     "revision": "d41d8cd98f00b204e9800998ecf8427e"
   }
 ])`;
-  VALID_INJECTION_DOCS.forEach((docName) => {
+  VALID_INJECTION_DOCS.forEach((docName, index) => {
     it(`should be able to read and inject in doc ${docName}`, function() {
+      const dest = path.join(tmpDirectory, `different-output-name-${index}.js`);
       return swBuild.injectManifest({
-        dest: tmpDirectory,
         globDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
         staticFileGlobs: ['**\/*.{html,css}'],
-        swFile: docName,
+        swPath: path.join(__dirname, '..', 'static', 'injection-samples', docName),
+        dest,
       })
       .then(() => {
-        const fileOutput =
-          fs.readFileSync(path.join(tmpDirectory, docName)).toString();
+        const fileOutput = fs.readFileSync(dest).toString();
         if (fileOutput.indexOf(expectedString) === -1) {
           console.log('DocName: ' + docName);
           console.log('fileOutput: ' + fileOutput);
@@ -57,10 +57,10 @@ describe('Test Injection Manifest', function() {
 
   it(`should throw due to no injection point in bad-no-injection.js`, function() {
     return swBuild.injectManifest({
-      dest: tmpDirectory,
       globDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
       staticFileGlobs: ['**\/*.{html,css}'],
-      swFile: 'bad-no-injection.js',
+      swPath: path.join(__dirname, '..', 'static', 'injection-samples', 'bad-no-injection.js'),
+      dest: path.join(tmpDirectory, 'different-output-name.js'),
     })
     .then(() => {
       throw new Error('Expected promise to reject.');
@@ -75,10 +75,10 @@ describe('Test Injection Manifest', function() {
 
   it(`should throw due to no injection point in bad-multiple-injection.js`, function() {
     return swBuild.injectManifest({
-      dest: tmpDirectory,
       globDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
       staticFileGlobs: ['**\/*.{html,css}'],
-      swFile: 'bad-multiple-injection.js',
+      swPath: path.join(__dirname, '..', 'static', 'injection-samples', 'bad-multiple-injection.js'),
+      dest: path.join(tmpDirectory, 'different-output-name.js'),
     })
     .then(() => {
       throw new Error('Expected promise to reject.');

--- a/packages/sw-build/test/node/injection-manifest.js
+++ b/packages/sw-build/test/node/injection-manifest.js
@@ -39,7 +39,7 @@ describe('Test Injection Manifest', function() {
     it(`should be able to read and inject in doc ${docName}`, function() {
       return swBuild.injectManifest({
         dest: tmpDirectory,
-        rootDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
+        globDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
         staticFileGlobs: ['**\/*.{html,css}'],
         swFile: docName,
       })
@@ -58,7 +58,7 @@ describe('Test Injection Manifest', function() {
   it(`should throw due to no injection point in bad-no-injection.js`, function() {
     return swBuild.injectManifest({
       dest: tmpDirectory,
-      rootDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
+      globDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
       staticFileGlobs: ['**\/*.{html,css}'],
       swFile: 'bad-no-injection.js',
     })
@@ -76,7 +76,7 @@ describe('Test Injection Manifest', function() {
   it(`should throw due to no injection point in bad-multiple-injection.js`, function() {
     return swBuild.injectManifest({
       dest: tmpDirectory,
-      rootDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
+      globDirectory: path.join(__dirname, '..', 'static', 'injection-samples'),
       staticFileGlobs: ['**\/*.{html,css}'],
       swFile: 'bad-multiple-injection.js',
     })

--- a/packages/sw-cli/src/index.js
+++ b/packages/sw-cli/src/index.js
@@ -113,20 +113,20 @@ class SWCli {
       }
     })
     .then(() => {
-      if (!config.rootDirectory) {
+      if (!config.globDirectory) {
         return askForRootOfWebApp()
         .then((rDirectory) => {
           // This will give a pretty relative path:
           // '' => './'
           // 'build' => './build/'
-          config.rootDirectory =
+          config.globDirectory =
             path.join('.', path.relative(process.cwd(), rDirectory), path.sep);
         });
       }
     })
     .then(() => {
       if (!config.staticFileGlobs) {
-        return askForExtensionsToCache(config.rootDirectory)
+        return askForExtensionsToCache(config.globDirectory)
         .then((extensionsToCache) => {
           config.staticFileGlobs = [
             generateGlobPattern(extensionsToCache),
@@ -138,7 +138,7 @@ class SWCli {
       if (!config.dest) {
         return askForServiceWorkerName()
         .then((swName) => {
-          config.dest = path.join(config.rootDirectory, swName);
+          config.dest = path.join(config.globDirectory, swName);
           config.globIgnores = [
             swName,
           ];
@@ -187,7 +187,7 @@ class SWCli {
     .then(() => {
       const globPattern = generateGlobPattern(fileExtentionsToCache);
       return swBuild.generateFileManifest({
-        rootDirectory: rootDirPath,
+        globDirectory: rootDirPath,
         staticFileGlobs: [globPattern],
         globIgnores: [
           fileManifestName,

--- a/packages/sw-cli/src/lib/questions/ask-extensions-to-cache.js
+++ b/packages/sw-cli/src/lib/questions/ask-extensions-to-cache.js
@@ -66,11 +66,11 @@ const getFileExtensions = (files) => {
 
 /**
  * @private
- * @param {String} rootDirectory
+ * @param {String} globDirectory
  * @return {Promise<Array<String>>}
  */
-module.exports = (rootDirectory) => {
-  return getFileContents(rootDirectory)
+module.exports = (globDirectory) => {
+  return getFileContents(globDirectory)
   .then((files) => {
     return getFileExtensions(files);
   })

--- a/packages/sw-cli/test/node/cli-file-extensions.js
+++ b/packages/sw-cli/test/node/cli-file-extensions.js
@@ -39,9 +39,7 @@ describe('Ask for File Extensions to Cache', function() {
       captured.consoleLogs.length.should.equal(0);
       captured.consoleWarns.length.should.equal(0);
       captured.consoleErrors.length.should.not.equal(0);
-      console.log('expectedErrorCode: ', expectedErrorCode);
-      console.log('errors[expectedErrorCode]: ', errors[expectedErrorCode]);
-      console.log('<------------', captured);
+
       let foundErrorMsg = false;
       let foundInjectedErrorMsg = false;
       captured.consoleErrors.forEach((errLog) => {

--- a/packages/sw-cli/test/node/generate-sw-e2e.js
+++ b/packages/sw-cli/test/node/generate-sw-e2e.js
@@ -48,7 +48,7 @@ describe('Generate SW End-to-End Tests', function() {
       path.join(__dirname, '..', 'static', 'example-project-1'),
       tmpDirectory);
 
-    const swName = `${Date.now()}-sw.js`;
+    const dest = `build/${Date.now()}-sw.js`;
 
     let enforceNoQuestions = false;
     const SWCli = proxyquire('../../build/index', {
@@ -62,7 +62,7 @@ describe('Generate SW End-to-End Tests', function() {
         if (enforceNoQuestions) {
           return Promise.reject('Injected Error - No Questions Expected');
         }
-        return Promise.resolve(swName);
+        return Promise.resolve(dest);
       },
       './lib/questions/ask-save-config': () => {
         if (enforceNoQuestions) {
@@ -83,7 +83,7 @@ describe('Generate SW End-to-End Tests', function() {
       return cli.handleCommand('generate:sw');
     }, {
       exampleProject: tmpDirectory,
-      swName,
+      dest,
       fileExtensions: FILE_EXTENSIONS,
       baseTestUrl,
     })
@@ -94,7 +94,7 @@ describe('Generate SW End-to-End Tests', function() {
         return cli.handleCommand('generate:sw');
       }, {
         exampleProject: tmpDirectory,
-        swName,
+        dest,
         fileExtensions: FILE_EXTENSIONS,
         baseTestUrl,
       });

--- a/packages/sw-cli/test/static/example-project-1/index.html
+++ b/packages/sw-cli/test/static/example-project-1/index.html
@@ -33,7 +33,7 @@
     if (split[1].indexOf('/') === split[1].length - 1) {
       split[1] = split[1].substring(0, split[1].length - 1);
     }
-    searchParams[split[0]] = split[1];
+    searchParams[split[0]] = decodeURIComponent(split[1]);
   });
   navigator.serviceWorker.register(searchParams.sw)
   .then((registration) => {


### PR DESCRIPTION
R: @jeffposnick @addyosmani @prateekbh 

Fixes #451 #453 

This makes a few changes:
- rootDirectory is now globDirectory
- dest must now be a full path for the output file
- swFile is now swPath and is seperate from anything else.

This actually sanitzed a lot of logic which is normally a good sign that the API is a better way to go.

Let me know what you think (Prateek I changed the swFile to swPath in the plugin, please let me know if that's not ok).