### PR TITLE
staleWhileRevalidate() is the new fastest()

### DIFF
--- a/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
+++ b/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
@@ -24,7 +24,10 @@ import assert from '../../../../lib/assert';
  *
  * In addition to updating the appropriate caches, it will also trigger any
  * appropriate plugins defined in the underlying `RequestWrapper`.
- * XXXXXXXX
+ * 
+ * This class always returns the cache and returns it first regardless of how
+ * quickly a network response returns. This make it suitable for scenarios where
+ * a fastest strategy would otherwise be used.
  *
  * By default, `StaleWhileRevalidate` will cache responses with a 200 status
  * code as well as [opaque responses](http://stackoverflow.com/q/39109789)

--- a/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
+++ b/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
@@ -22,12 +22,14 @@ import assert from '../../../../lib/assert';
  * An implementation of a [stale-while-revalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate)
  * request strategy.
  *
- * In addition to updating the appropriate caches, it will also trigger any
- * appropriate plugins defined in the underlying `RequestWrapper`.
- * 
- * This class always returns the cache and returns it first regardless of how
- * quickly a network response returns. This make it suitable for scenarios where
- * a fastest strategy would otherwise be used.
+ * Resources are requested from both the cache and the network in parallel, then
+ * responds with the cached version. The cache is replaced with whatever returns
+ * from the network. In addition to updating the appropriate caches, it will
+ * also trigger any appropriate plugins defined in the underlying `RequestWrapper`.
+ *
+ * This strategy is the closest equivalent to the sw-toolbox
+ * [fastest](https://googlechrome.github.io/sw-toolbox/api.html#toolboxfastest)
+ * strategy.
  *
  * By default, `StaleWhileRevalidate` will cache responses with a 200 status
  * code as well as [opaque responses](http://stackoverflow.com/q/39109789)

--- a/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
+++ b/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
@@ -25,7 +25,8 @@ import assert from '../../../../lib/assert';
  * Resources are requested from both the cache and the network in parallel, then
  * responds with the cached version. The cache is replaced with whatever returns
  * from the network. In addition to updating the appropriate caches, it will
- * also trigger any appropriate plugins defined in the underlying `RequestWrapper`.
+ * also trigger any appropriate plugins defined in the underlying
+ * `RequestWrapper`.
  *
  * This strategy is the closest equivalent to the sw-toolbox
  * [fastest](https://googlechrome.github.io/sw-toolbox/api.html#toolboxfastest)

--- a/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
+++ b/packages/sw-runtime-caching/src/lib/stale-while-revalidate.js
@@ -24,6 +24,7 @@ import assert from '../../../../lib/assert';
  *
  * In addition to updating the appropriate caches, it will also trigger any
  * appropriate plugins defined in the underlying `RequestWrapper`.
+ * XXXXXXXX
  *
  * By default, `StaleWhileRevalidate` will cache responses with a 200 status
  * code as well as [opaque responses](http://stackoverflow.com/q/39109789)


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

Fixes #316 

Clarify that that staleWhileRevalidate() is the new fastest().

*Please ensure that `gulp lint test` passes locally prior to filing a PR!* 

__Fails on files that I'm not touching in this PR.__
