### PR TITLE
Major revamp of the build process

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -23,7 +23,7 @@ const fsePromise = promisify('fs-extra');
 
 const printHeading = (heading) => {
   /* eslint-disable no-console */
-  process.stdout.write(chalk.inverse(`  ⚒️  ${heading}  `));
+  process.stdout.write(chalk.inverse(`  ⚒  ${heading}  `));
   /* eslint-enable no-console */
 };
 
@@ -32,7 +32,7 @@ const printBuildTime = (buildTime) => {
 };
 
 /**
- * Buids a given project.
+ * Builds a given project.
  * @param {String} projectPath The path to a project directory.
  * @return {Promise} Resolves if building succeeds, rejects if it fails.
  */

--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
     "update-notifier": "^2.1.0"
   },
   "devDependencies": {
-    "babel-plugin-external-helpers": "^6.8.0",
-    "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-preset-babili": "0.0.12",
-    "babel-preset-es2015": "^6.16.0",
     "chai": "^3.5.0",
     "chromedriver": "^2.26.1",
     "clear-require": "^2.0.0",
@@ -46,15 +43,10 @@
     "geckodriver": "1.6.0",
     "glob": "^7.1.0",
     "gulp": "^3.9.1",
-    "gulp-babel": "^6.1.2",
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-eslint": "^3.0.1",
-    "gulp-header": "^1.8.8",
-    "gulp-if": "^2.0.2",
     "gulp-insert": "^0.5.0",
     "gulp-rename": "^1.2.2",
-    "gulp-rollup": "^2.5.1",
-    "gulp-sourcemaps": "^2.4.0",
     "gulp-spawn-mocha": "^3.1.0",
     "handlebars": "^4.0.6",
     "jsdoc-strip-async-await": "^0.1.0",
@@ -65,6 +57,7 @@
     "path-to-regexp": "^1.6.0",
     "promisify-node": "^0.4.0",
     "proxyquire": "^1.7.10",
+    "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
@@ -74,6 +67,7 @@
     "serve-static": "^1.11.1",
     "sinon": "^2.1.0",
     "sw-testing-helpers": "^1.0.2",
-    "tmp": "0.0.31"
+    "tmp": "0.0.31",
+    "uppercamelcase": "^3.0.0"
   }
 }

--- a/packages/sw-background-sync-queue/test/browser/background-sync-idb-helper.js
+++ b/packages/sw-background-sync-queue/test/browser/background-sync-idb-helper.js
@@ -19,15 +19,15 @@
 describe('background-sync-idb-helper test', () => {
   it('check defaults', () => {
     chai.assert.equal(
-      goog.backgroundSyncQueue.test.backgroundSyncIdbHelper.getDbName(),
-      goog.backgroundSyncQueue.test.constants.defaultDBName);
+      goog.backgroundSyncQueue.test.BackgroundSyncIdbHelper.getDbName(),
+      goog.backgroundSyncQueue.test.Constants.defaultDBName);
   });
 
   it('check getters and setters', () => {
     const newDbName = 'DB_NAME_2';
-    goog.backgroundSyncQueue.test.backgroundSyncIdbHelper.setDbName(newDbName);
+    goog.backgroundSyncQueue.test.BackgroundSyncIdbHelper.setDbName(newDbName);
     chai.assert.equal(
-      goog.backgroundSyncQueue.test.backgroundSyncIdbHelper.getDbName(),
+      goog.backgroundSyncQueue.test.BackgroundSyncIdbHelper.getDbName(),
       newDbName);
   });
 });

--- a/packages/sw-background-sync-queue/test/browser/background-sync-queue.js
+++ b/packages/sw-background-sync-queue/test/browser/background-sync-queue.js
@@ -43,9 +43,9 @@ describe('background sync queue test', () => {
     chai.assert.isObject(defaultsBackgroundSyncQueue._queue);
     chai.assert.isObject(defaultsBackgroundSyncQueue._requestManager);
     chai.assert.equal(defaultsBackgroundSyncQueue._queue._queueName,
-      goog.backgroundSyncQueue.test.constants.defaultQueueName + '_0');
+      goog.backgroundSyncQueue.test.Constants.defaultQueueName + '_0');
     chai.assert.equal(defaultsBackgroundSyncQueue._queue._config.maxAge,
-      goog.backgroundSyncQueue.test.constants.maxAge);
+      goog.backgroundSyncQueue.test.Constants.maxAge);
     chai.assert.equal(
       JSON.stringify(
         defaultsBackgroundSyncQueue._requestManager._globalCallbacks),

--- a/packages/sw-background-sync-queue/test/browser/broadcast-manager.js
+++ b/packages/sw-background-sync-queue/test/browser/broadcast-manager.js
@@ -17,8 +17,7 @@
 'use strict';
 
 describe('broadcast manager test', () => {
-	const broadcastManager
-    = goog.backgroundSyncQueue.test.broadcastManager;
+	const broadcastManager = goog.backgroundSyncQueue.test.BroadcastManager;
 
   it('check broadcast', function(done) {
 		this.timeout(100);

--- a/packages/sw-background-sync-queue/test/browser/queue-utils.js
+++ b/packages/sw-background-sync-queue/test/browser/queue-utils.js
@@ -25,14 +25,14 @@ function delay(timeout) {
 }
 
 describe('queue-utils test', () => {
-	const queueUtils = goog.backgroundSyncQueue.test.queueUtils;
+	const queueUtils = goog.backgroundSyncQueue.test.QueueUtils;
 	const maxAgeTimeStamp = 1000*60*60*24;
 	const config = {
 		maxAge: maxAgeTimeStamp,
 	};
 
 	beforeEach(function() {
-		const idbHelper = new goog.backgroundSyncQueue.test.IDBHelper(
+		const idbHelper = new goog.backgroundSyncQueue.test.IdbHelper(
 			'bgQueueSyncDB', 1, 'QueueStore');
 		return idbHelper.getAllKeys()
 		.then((keys) => {
@@ -79,7 +79,7 @@ describe('queue-utils test', () => {
 	});
 
 	it('test queue cleanup', async () => {
-		const idbHelper = new goog.backgroundSyncQueue.test.IDBHelper(
+		const idbHelper = new goog.backgroundSyncQueue.test.IdbHelper(
 			'bgQueueSyncDB', 1, 'QueueStore');
 		await queueUtils.cleanupQueue();
 		/* code for clearing everything from IDB */

--- a/packages/sw-background-sync-queue/test/browser/request-manager.js
+++ b/packages/sw-background-sync-queue/test/browser/request-manager.js
@@ -23,7 +23,7 @@ describe('request-manager test', () => {
 			responseAchieved ++;
 		},
 	};
-	const swBackgroundQueue = goog.backgroundSyncQueue.test.swBackgroundQueue;
+	const swBackgroundQueue = goog.backgroundSyncQueue;
 
 	let queue;
 	let reqManager;

--- a/packages/sw-background-sync-queue/test/browser/request-queue.js
+++ b/packages/sw-background-sync-queue/test/browser/request-queue.js
@@ -39,7 +39,7 @@ describe('request-queue tests', () => {
   it('config is correct', () => {
     chai.assert.equal(queue._config.maxAge, MAX_AGE);
     chai.assert.notEqual(
-      queue._config.maxAge, goog.backgroundSyncQueue.test.constants.maxAge);
+      queue._config.maxAge, goog.backgroundSyncQueue.test.Constants.maxAge);
   });
 
   it('pushRequest is working', () => {
@@ -55,8 +55,8 @@ describe('request-queue tests', () => {
     let tempQueue2 = new goog.backgroundSyncQueue.test.RequestQueue({});
     chai.assert.equal(tempQueue._config, undefined);
     chai.assert.equal(tempQueue._queueName,
-      goog.backgroundSyncQueue.test.constants.defaultQueueName + '_0');
+      goog.backgroundSyncQueue.test.Constants.defaultQueueName + '_0');
     chai.assert.equal(tempQueue2._queueName,
-      goog.backgroundSyncQueue.test.constants.defaultQueueName + '_1');
+      goog.backgroundSyncQueue.test.Constants.defaultQueueName + '_1');
   });
 });

--- a/packages/sw-background-sync-queue/test/browser/response-manager.js
+++ b/packages/sw-background-sync-queue/test/browser/response-manager.js
@@ -22,9 +22,9 @@ describe('response-manager test', () => {
   let resManager;
 
   before(() => {
-    idbHelper = new goog.backgroundSyncQueue.test.IDBHelper(
+    idbHelper = new goog.backgroundSyncQueue.test.IdbHelper(
       'bgQueueSyncDB', 1, 'QueueStore');
-    resManager = goog.backgroundSyncQueue.test.responseManager;
+    resManager = goog.backgroundSyncQueue.test.ResponseManager;
   });
 
   it('check get', () => {

--- a/packages/sw-background-sync-queue/test/config.json
+++ b/packages/sw-background-sync-queue/test/config.json
@@ -3,16 +3,16 @@
     "scripts": [
       "/node_modules/mockdate/src/mockdate.js",
       "/node_modules/sinon/pkg/sinon.js",
-      "/packages/sw-background-sync-queue/build/test/idb-helper.js",
-      "/packages/sw-background-sync-queue/build/test/constants.js",
-      "/packages/sw-background-sync-queue/build/test/request-queue.js",
-      "/packages/sw-background-sync-queue/build/test/request-manager.js",
-      "/packages/sw-background-sync-queue/build/test/response-manager.js",
-      "/packages/sw-background-sync-queue/build/test/background-sync-queue.js",
+      "/packages/sw-background-sync-queue/build/background-sync-queue.js",
       "/packages/sw-background-sync-queue/build/test/background-sync-idb-helper.js",
-      "/packages/sw-background-sync-queue/build/test/queue-utils.js",
+      "/packages/sw-background-sync-queue/build/test/background-sync-queue.js",
       "/packages/sw-background-sync-queue/build/test/broadcast-manager.js",
-      "/packages/sw-background-sync-queue/build/test/sw-background-queue.js"
+      "/packages/sw-background-sync-queue/build/test/constants.js",
+      "/packages/sw-background-sync-queue/build/test/idb-helper.js",
+      "/packages/sw-background-sync-queue/build/test/queue-utils.js",
+      "/packages/sw-background-sync-queue/build/test/request-manager.js",
+      "/packages/sw-background-sync-queue/build/test/request-queue.js",
+      "/packages/sw-background-sync-queue/build/test/response-manager.js"
     ]
   }
 }

--- a/packages/sw-broadcast-cache-update/build.js
+++ b/packages/sw-broadcast-cache-update/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.broadcastCacheUpdate');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.broadcastCacheUpdate',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cache-expiration/build.js
+++ b/packages/sw-cache-expiration/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.cacheExpiration');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.cacheExpiration',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-cacheable-response/build.js
+++ b/packages/sw-cacheable-response/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.cacheableResponse');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.cacheableResponse',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-lib/build.js
+++ b/packages/sw-lib/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.SWLib');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.SWLib',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-offline-google-analytics/test/browser/enqueue-request.js
+++ b/packages/sw-offline-google-analytics/test/browser/enqueue-request.js
@@ -17,9 +17,9 @@
 'use strict';
 
 describe('enqueue-request', () => {
-  const enqueueRequest = goog.offlineGoogleAnalytics.test.enqueueRequest;
-  const constants = goog.offlineGoogleAnalytics.test.constants;
-  const IDBHelper = goog.offlineGoogleAnalytics.test.IDBHelper;
+  const enqueueRequest = goog.offlineGoogleAnalytics.test.EnqueueRequest;
+  const constants = goog.offlineGoogleAnalytics.test.Constants;
+  const IDBHelper = goog.offlineGoogleAnalytics.test.IdbHelper;
 
   const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
     constants.IDB.STORE);

--- a/packages/sw-offline-google-analytics/test/browser/replay-queued-requests.js
+++ b/packages/sw-offline-google-analytics/test/browser/replay-queued-requests.js
@@ -17,10 +17,10 @@
 'use strict';
 
 describe('replay-queued-requests', () => {
-  const constants = goog.offlineGoogleAnalytics.test.constants;
-  const enqueueRequest = goog.offlineGoogleAnalytics.test.enqueueRequest;
-  const replayRequests = goog.offlineGoogleAnalytics.test.replayRequests;
-  const IDBHelper = goog.offlineGoogleAnalytics.test.IDBHelper;
+  const constants = goog.offlineGoogleAnalytics.test.Constants;
+  const enqueueRequest = goog.offlineGoogleAnalytics.test.EnqueueRequest;
+  const replayRequests = goog.offlineGoogleAnalytics.test.ReplayQueuedRequests;
+  const IDBHelper = goog.offlineGoogleAnalytics.test.IdbHelper;
 
   const idbHelper = new IDBHelper(constants.IDB.NAME, constants.IDB.VERSION,
      constants.IDB.STORE);

--- a/packages/sw-precaching/build.js
+++ b/packages/sw-precaching/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.precaching');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.precaching',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-routing/build.js
+++ b/packages/sw-routing/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.routing');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.routing',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));

--- a/packages/sw-runtime-caching/build.js
+++ b/packages/sw-runtime-caching/build.js
@@ -17,8 +17,12 @@ const pkg = require('./package.json');
 const {buildJSBundle, generateBuildConfigs} = require('../../utils/build');
 
 const buildConfigs = generateBuildConfigs({
-  es: pkg['jsnext:main'],
-  umd: pkg.main,
-}, __dirname, 'goog.runtimeCaching');
+  formatToPath: {
+    es: pkg['jsnext:main'],
+    iife: pkg.main,
+  },
+  baseDir: __dirname,
+  moduleName: 'goog.runtimeCaching',
+});
 
 module.exports = () => Promise.all(buildConfigs.map(buildJSBundle));


### PR DESCRIPTION
R: @addyosmani @gauntface

This is a substantial update to the build process, with the following changes:
- Moving from gulp wrappers on top of Rollup, babili, and others to directly using Rollup. This fixes #477, sourcemap generation.
- No longer including the async-to-generator transpilation, since async/await are natively supported in production Chrome and Firefox. We can turn this back on if we need.
- Changing the build process for `sw-offline-google-analytics` and `sw-background-sync-queue` to only generate unminimized `iife` bundles of the individual `.js` files that they need in order to run their tests, and to generate them all in parallel instead of sequentially.
- Adding in an `.npmignore` file to the directory that hosts the built tests for `sw-offline-google-analytics` and `sw-background-sync-queue` to ensure they're not published to `npm`.

As a result of these changes, we've saved a modest ~364 bytes on the gzip-ed size of `swlib.min.js`. But the built times should be much quicker across the board—I've seen improvements of around 10 seconds in `sw-lib`, and up to 40 seconds improvement for `sw-background-sync-queue` (which was really bad to begin with, due to a long sequential chain of bundled test code).