### PR TITLE
Trim landing page text.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,9 @@ navigation_weight: 0
 # Welcome to Workbox
 
 Workbox is a suite of helper libraries for service workers and progressive web
-apps designed to simplify your development experience. 
-
-Wokrbox lets you implement precaching in a manner of minutes.
-The full set of features supports such things as runtime caching, routing,
-offline analytics, background syncing, and more.
+apps that lets you implement precaching in a manner of minutes. Its features
+support runtime caching, routing, offline analytics, background syncing, and
+more.
 
 ## A service worker in two minutes
 


### PR DESCRIPTION
R: @jeffposnick @addyosmani @gauntface

In my feedback for the Occupop mockups I said that visual assets took too much space and pushed content that we want people to read off the visible area. I mentioned that thinning my own text would also help this. 