### PR TITLE
Omit error-stack-parser from the minified bundles

### DIFF
--- a/lib/assert-min.js
+++ b/lib/assert-min.js
@@ -1,0 +1,28 @@
+/*
+ Copyright 2017 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+const noop = () => true;
+
+export default {
+  atLeastOne: noop,
+  hasMethod: noop,
+  isInstance: noop,
+  isOneOf: noop,
+  isType: noop,
+  isSWEnv: noop,
+  isValue: noop,
+  isArrayOfType: noop,
+  isArrayOfClass: noop,
+};

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -106,6 +106,9 @@ function isValue(object, expectedValue) {
 }
 
 function throwError(message) {
+  // Collapse any newlines or whitespace into a single space.
+  message = message.replace(/\s+/g, ' ');
+
   const error = new Error(message);
   const stackFrames = ErrorStackParser.parse(error);
 
@@ -116,7 +119,7 @@ function throwError(message) {
     // about what the underlying method was, and set the name to reflect
     // the assertion type that failed.
     error.message = `Invalid call to ${stackFrames[2].functionName}() — ` +
-      message.replace(/\s+/g, ' ');
+      message;
     error.name = stackFrames[1].functionName.replace(/^Object\./, '');
   }
 

--- a/lib/error-stack-parser-no-op.js
+++ b/lib/error-stack-parser-no-op.js
@@ -1,10 +1,10 @@
 /*
- Copyright 2017 Google Inc. All Rights Reserved.
+ Copyright 2016 Google Inc. All Rights Reserved.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,16 +13,10 @@
  limitations under the License.
 */
 
-const noop = () => true;
-
+/**
+ * A no-op export matching the ErrorStackParser interface, to be included in
+ * production, minified builds.
+ */
 export default {
-  atLeastOne: noop,
-  hasMethod: noop,
-  isInstance: noop,
-  isOneOf: noop,
-  isType: noop,
-  isSWEnv: noop,
-  isValue: noop,
-  isArrayOfType: noop,
-  isArrayOfClass: noop,
+  parse: () => [],
 };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^1.1.1",
     "run-sequence": "^1.2.2",
     "selenium-assistant": "^5.0.5",
     "serve-index": "^1.8.0",

--- a/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update-plugin.js
+++ b/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update-plugin.js
@@ -2,7 +2,7 @@ importScripts(
   '/node_modules/mocha/mocha.js',
   '/node_modules/chai/chai.js',
   '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
-  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
+  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.js'
 );
 
 const expect = self.chai.expect;

--- a/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update.js
+++ b/packages/sw-broadcast-cache-update/test/sw/broadcast-cache-update.js
@@ -2,7 +2,7 @@ importScripts(
   '/node_modules/mocha/mocha.js',
   '/node_modules/chai/chai.js',
   '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
-  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
+  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.js'
 );
 
 const expect = self.chai.expect;

--- a/packages/sw-broadcast-cache-update/test/sw/namespace.js
+++ b/packages/sw-broadcast-cache-update/test/sw/namespace.js
@@ -2,7 +2,7 @@ importScripts(
   '/node_modules/mocha/mocha.js',
   '/node_modules/chai/chai.js',
   '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
-  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
+  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.js'
 );
 
 const expect = self.chai.expect;

--- a/packages/sw-broadcast-cache-update/test/sw/responses-are-same.js
+++ b/packages/sw-broadcast-cache-update/test/sw/responses-are-same.js
@@ -2,7 +2,7 @@ importScripts(
   '/node_modules/mocha/mocha.js',
   '/node_modules/chai/chai.js',
   '/node_modules/sw-testing-helpers/build/browser/mocha-utils.js',
-  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.min.js'
+  '/packages/sw-broadcast-cache-update/build/sw-broadcast-cache-update.js'
 );
 
 const expect = self.chai.expect;

--- a/utils/build.js
+++ b/utils/build.js
@@ -15,14 +15,15 @@
 
 /* eslint-disable no-console, valid-jsdoc */
 
+const babel = require('rollup-plugin-babel');
 const childProcess = require('child_process');
 const commonjs = require('rollup-plugin-commonjs');
 const fs = require('fs');
 const path = require('path');
 const promisify = require('promisify-node');
+const replace = require('rollup-plugin-replace');
 const resolve = require('rollup-plugin-node-resolve');
 const rollup = require('rollup').rollup;
-const rollupBabel = require('rollup-plugin-babel');
 
 const globPromise = promisify('glob');
 
@@ -122,13 +123,17 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
                                 entry}) {
   const buildConfigs = [];
 
-  const babelPluginMinify = rollupBabel({
+  const babelPlugin = babel({
     presets: [['babili', {
       comments: false,
     }]],
   });
 
-  const plugins = [
+  const replacePlugin = replace({
+    '/lib/assert': '/lib/assert-min',
+  });
+
+  const basePlugins = [
     resolve({
       jsnext: true,
       main: true,
@@ -141,7 +146,7 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
     buildConfigs.push({
       rollupConfig: {
         entry: entry || path.join(baseDir, 'src', 'index.js'),
-        plugins,
+        plugins: basePlugins,
       },
       writeConfig: {
         banner: LICENSE_HEADER,
@@ -157,7 +162,7 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
       buildConfigs.push({
         rollupConfig: {
           entry: entry || path.join(baseDir, 'src', 'index.js'),
-          plugins: plugins.concat(babelPluginMinify),
+          plugins: [replacePlugin, ...basePlugins, babelPlugin],
         },
         writeConfig: {
           banner: LICENSE_HEADER,

--- a/utils/build.js
+++ b/utils/build.js
@@ -129,8 +129,11 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
     }]],
   });
 
+  // This will replace the usage of the (somewhat large) error-stack-parser
+  // module with a no-op module that has the same interface. It sacrifices some
+  // debugging info in exchange for a smaller minimized bundle.
   const replacePlugin = replace({
-    '/lib/assert': '/lib/assert-min',
+    'error-stack-parser': './error-stack-parser-no-op',
   });
 
   const basePlugins = [


### PR DESCRIPTION
R: @addyosmani @gauntface

This is based off the discussion in https://github.com/GoogleChrome/sw-helpers/issues/361#issuecomment-298640521

It swaps out the real [`error-stack-parser`](https://www.npmjs.com/package/error-stack-parser) module import for an import that has the same interface but is effectively a no-op. You lose a bit of context if an assertion fails without the real module, but our assertions are really meant to catch errors in a development environment, not after the service worker has been deployed.

This gets the production `sw-lib.min.js` bundle size down from 50249 bytes (14938 bytes gzip-ed) to 45450 bytes (13468 bytes gzip-ed).

I had to change a few of the tests that specifically examined the assertion failures to use the unminified bundle, but other than that, it's much less of a hack than it could have been.