### PR TITLE
Build output normalization for CommonJS/node projects.

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -32,19 +32,19 @@ const printBuildTime = (buildTime) => {
 /**
  * Builds a given project.
  * @param {String} projectPath The path to a project directory.
+ * @return {Promise} Resolves if building succeeds, rejects if it fails.
  */
-const buildPackage = async (projectPath) => {
+const buildPackage = (projectPath) => {
   printHeading(`Building ${path.basename(projectPath)}`);
   const startTime = Date.now();
   const buildDir = `${projectPath}/build`;
+  const projectBuildProcess = require(`${projectPath}/build.js`);
 
-  await fse.emptyDir(buildDir);
-  const build = require(`${projectPath}/build.js`);
-  await build();
-  await fse.copy(path.join(__dirname, '..', 'LICENSE'),
-    path.join(projectPath, 'LICENSE'));
-
-  printBuildTime(((Date.now() - startTime) / 1000) + 's');
+  return fse.emptyDir(buildDir)
+    .then(() => projectBuildProcess())
+    .then(() => fse.copy(path.join(__dirname, '..', 'LICENSE'),
+      path.join(projectPath, 'LICENSE')))
+    .then(() => printBuildTime(`${(Date.now() - startTime) / 1000}s`));
 };
 
 gulp.task('build:shared', () => {

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -22,11 +22,11 @@ const path = require('path');
 const {taskHarness, buildJSBundle} = require('../utils/build');
 
 const printHeading = (heading) => {
-  process.stdout.write(chalk.inverse(`  ⚒ ${heading}`));
+  process.stdout.write(chalk.inverse(`  ⚒  ${heading}  `));
 };
 
 const printBuildTime = (buildTime) => {
-  process.stdout.write(chalk.inverse(` (${buildTime})\n`));
+  process.stdout.write(chalk.inverse(`(${buildTime})\n`));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "error-stack-parser": "^2.0.0",
     "eslint-config-google": "^0.7.0",
     "express": "^4.14.0",
-    "fs-extra": "^2.0.0",
+    "fs-extra": "^3.0.1",
     "geckodriver": "1.6.0",
     "glob": "^7.1.0",
     "gulp": "^3.9.1",

--- a/packages/sw-build-webpack-plugin/build.js
+++ b/packages/sw-build-webpack-plugin/build.js
@@ -13,23 +13,10 @@
  limitations under the License.
 */
 
-const fsExtra = require('fs-extra');
+const fse = require('fs-extra');
 const path = require('path');
 
-const copyPath = (from, to) => {
-  return new Promise((resolve, reject) => {
-    fsExtra.copy(from, to, (err) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve();
-    });
-  });
-};
-
 module.exports = () => {
-  return copyPath(
-    path.join(__dirname, 'index.js'),
-    path.join(__dirname, 'build/index.js')
-  );
+  return fse.copy(path.join(__dirname, 'index.js'),
+    path.join(__dirname, 'build', 'index.js'));
 };

--- a/packages/sw-build-webpack-plugin/package.json
+++ b/packages/sw-build-webpack-plugin/package.json
@@ -11,10 +11,11 @@
     "offline",
     "file manifest"
   ],
-  "scripts": {},
-  "main": "index.js",
+  "scripts": {
+    "prepublish": "gulp build --project sw-build-webpack-plugin"
+  },
+  "main": "build/index.js",
   "files": [
-    "src",
     "build"
   ],
   "engines": {

--- a/packages/sw-build-webpack-plugin/package.json
+++ b/packages/sw-build-webpack-plugin/package.json
@@ -24,6 +24,9 @@
   "dependencies": {
     "sw-build": "^0.0.20"
   },
+  "devDependencies": {
+    "fs-extra": "^3.0.1"
+  },
   "author": "Google's Web DevRel Team",
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",

--- a/packages/sw-build/build.js
+++ b/packages/sw-build/build.js
@@ -13,23 +13,9 @@
  limitations under the License.
 */
 
-const fsExtra = require('fs-extra');
+const fse = require('fs-extra');
 const path = require('path');
 
-const copyPath = (from, to) => {
-  return new Promise((resolve, reject) => {
-    fsExtra.copy(from, to, (err) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve();
-    });
-  });
-};
-
 module.exports = () => {
-  return copyPath(
-    path.join(__dirname, 'src/'),
-    path.join(__dirname, 'build/')
-  );
+  return fse.copy(path.join(__dirname, 'src'), path.join(__dirname, 'build'));
 };

--- a/packages/sw-build/package.json
+++ b/packages/sw-build/package.json
@@ -15,7 +15,6 @@
   },
   "main": "build/index.js",
   "files": [
-    "src",
     "build"
   ],
   "engines": {
@@ -32,8 +31,5 @@
     "lodash.template": "^4.4.0",
     "mkdirp": "^0.5.1",
     "sw-lib": "^0.0.20"
-  },
-  "devDependencies": {
-    "fs-extra": "^2.0.0"
   }
 }

--- a/packages/sw-build/package.json
+++ b/packages/sw-build/package.json
@@ -31,5 +31,8 @@
     "lodash.template": "^4.4.0",
     "mkdirp": "^0.5.1",
     "sw-lib": "^0.0.20"
+  },
+  "devDependencies": {
+    "fs-extra": "^3.0.1"
   }
 }

--- a/packages/sw-cli/build.js
+++ b/packages/sw-cli/build.js
@@ -13,23 +13,9 @@
  limitations under the License.
 */
 
-const fsExtra = require('fs-extra');
+const fse = require('fs-extra');
 const path = require('path');
 
-const copyPath = (from, to) => {
-  return new Promise((resolve, reject) => {
-    fsExtra.copy(from, to, (err) => {
-      if (err) {
-        return reject(err);
-      }
-      resolve();
-    });
-  });
-};
-
 module.exports = () => {
-  return copyPath(
-    path.join(__dirname, 'src/'),
-    path.join(__dirname, 'build/')
-  );
+  return fse.copy(path.join(__dirname, 'src'), path.join(__dirname, 'build'));
 };

--- a/packages/sw-cli/package.json
+++ b/packages/sw-cli/package.json
@@ -33,5 +33,8 @@
     "meow": "^3.7.0",
     "sw-build": "^0.0.20",
     "update-notifier": "^1.0.3"
+  },
+  "devDependencies": {
+    "fs-extra": "^3.0.1"
   }
 }

--- a/packages/sw-cli/package.json
+++ b/packages/sw-cli/package.json
@@ -14,7 +14,6 @@
     "sw-cli": "build/bin.js"
   },
   "files": [
-    "src",
     "build"
   ],
   "engines": {
@@ -34,8 +33,5 @@
     "meow": "^3.7.0",
     "sw-build": "^0.0.20",
     "update-notifier": "^1.0.3"
-  },
-  "devDependencies": {
-    "fs-extra": "^2.0.0"
   }
 }


### PR DESCRIPTION
R: @prateekbh @gauntface

This is the first half of #502, with some small changes to the build and `npm` packaging for the projects that are consumed as CommonJS modules or are CLIs.

`fs-extra` v3+ [supports promises natively now](https://github.com/jprichardson/node-fs-extra#usage) (yay!) so I was able to get rid of some of the extra explicit promise wrapping.