### PR TITLE
gulp wrappers for lerna boostrapping and publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 install:
   - npm install -g gulp-cli
   - npm install
-  - npm run lerna-bootstrap-scoped -- "${PROJECT}"
+  - gulp lerna-bootstrap-scoped --project="${PROJECT}"
 
 # Read more here: https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - ps: Install-Product node Stable
   - npm install
   - npm install -g gulp
-  - npm run lerna-bootstrap-scoped -- "sw-cli"
+  - gulp lerna-bootstrap-scoped --project="sw-cli"
   - cd packages/sw-cli/
   - npm install
   - cd ..

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-rc.3",
+  "lerna": "2.0.0-rc.4",
   "version": "0.0.24",
   "packages": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "local-docs": "npm-publish-scripts serve",
     "publish-docs": "npm-publish-scripts publish-docs",
-    "publish-release": "npm run lerna-bootstrap && gulp test && lerna publish --concurrency 1",
-    "lerna-bootstrap": "lerna bootstrap --concurrency 1",
-    "lerna-bootstrap-scoped": "lerna bootstrap --include-filtered-dependencies --concurrency 1 --scope"
+    "local-lerna": "lerna"
   },
   "version": "0.0.0",
   "description": "Top-level scripts and dependencies for the sw-helpers monorepo. Not meant to be published to npm.",
@@ -49,7 +47,7 @@
     "gulp-spawn-mocha": "^3.1.0",
     "handlebars": "^4.0.6",
     "jsdoc-strip-async-await": "^0.1.0",
-    "lerna": "2.0.0-rc.3",
+    "lerna": "2.0.0-rc.4",
     "minimist": "^1.2.0",
     "mockdate": "^2.0.1",
     "npm-publish-scripts": "^4.1.16",

--- a/packages/sw-cli/test/node/generate-sw-e2e.js
+++ b/packages/sw-cli/test/node/generate-sw-e2e.js
@@ -33,9 +33,8 @@ describe('Generate SW End-to-End Tests', function() {
   after(function() {
     this.timeout(10 * 1000);
 
-    fsExtra.removeSync(tmpDirectory);
-
-    return testServer.stop();
+    return testServer.stop()
+      .then(() => fsExtra.remove(tmpDirectory));
   });
 
   it('should be able to generate a service for example-1 with CLI', function() {

--- a/packages/sw-cli/test/node/generate-sw-e2e.js
+++ b/packages/sw-cli/test/node/generate-sw-e2e.js
@@ -34,6 +34,7 @@ describe('Generate SW End-to-End Tests', function() {
     this.timeout(10 * 1000);
 
     return testServer.stop()
+      .then(() => new Promise((resolve) => setTimeout(resolve, 2000)))
       .then(() => fsExtra.remove(tmpDirectory));
   });
 

--- a/packages/sw-cli/test/node/generate-sw-e2e.js
+++ b/packages/sw-cli/test/node/generate-sw-e2e.js
@@ -1,8 +1,8 @@
-const proxyquire = require('proxyquire');
-const path = require('path');
 const fs = require('fs');
-
 const fsExtra = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const proxyquire = require('proxyquire');
 
 const testServerGen = require('../../../../utils/test-server-generator.js');
 const validator = require('../utils/e2e-sw-validator.js');
@@ -18,9 +18,7 @@ describe('Generate SW End-to-End Tests', function() {
   const FILE_EXTENSIONS = ['html', 'css', 'js', 'png'];
 
   before(function() {
-    tmpDirectory = fs.mkdtempSync(
-      path.join(__dirname, 'tmp-')
-    );
+    tmpDirectory = fs.mkdtempSync(os.tmpdir() + path.sep);
 
     testServer = testServerGen();
     return testServer.start(tmpDirectory, 5050)
@@ -34,8 +32,8 @@ describe('Generate SW End-to-End Tests', function() {
     this.timeout(10 * 1000);
 
     return testServer.stop()
-      .then(() => new Promise((resolve) => setTimeout(resolve, 2000)))
-      .then(() => fsExtra.remove(tmpDirectory));
+      .then(() => fsExtra.remove(tmpDirectory))
+      .catch((error) => console.log(error));
   });
 
   it('should be able to generate a service for example-1 with CLI', function() {

--- a/utils/build.js
+++ b/utils/build.js
@@ -53,6 +53,18 @@ function processPromiseWrapper(command, args) {
 }
 
 /**
+ * Wrapper that runs the local node_modules/.bin/lerna binary, returning a
+ * promise when complete.
+ *
+ * @param args Arguments to pass to the local lerna binary.
+ * @return {Promise}
+ */
+function lernaWrapper(...args) {
+  return processPromiseWrapper('npm',
+    ['run', 'local-lerna', '--'].concat(args));
+}
+
+/**
  * Promise.all() rejects immediately as soon as the first Promise rejects.
  * This wrapper will run each Promise to resolution, and if one or more
  * rejected, reject at the end with a concatenated error message.
@@ -185,6 +197,7 @@ module.exports = {
   buildJSBundle,
   generateBuildConfigs,
   globPromise,
+  lernaWrapper,
   processPromiseWrapper,
   taskHarness,
 };

--- a/utils/build.js
+++ b/utils/build.js
@@ -19,6 +19,7 @@ const babel = require('rollup-plugin-babel');
 const childProcess = require('child_process');
 const commonjs = require('rollup-plugin-commonjs');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const promisify = require('promisify-node');
 const replace = require('rollup-plugin-replace');
@@ -60,7 +61,8 @@ function processPromiseWrapper(command, args) {
  * @return {Promise}
  */
 function lernaWrapper(...args) {
-  return processPromiseWrapper('npm',
+  const nodeCommand = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
+  return processPromiseWrapper(nodeCommand,
     ['run', 'local-lerna', '--'].concat(args));
 }
 


### PR DESCRIPTION
R: @addyosmani @gauntface

I **think** this ends up accomplishing what we want for publishing, via `gulp lerna-publish`.

It does it by:
1. Running the publishing flow with git and npm integration turned off. This updates the `package.json` and `lerna.json` `version` fields for the modified packages in the local working directory, without committing anything.
2. Automatically updating the `main` and `module` fields of all packages to pick up any modified versions.
3. Re-running the publishing flow, this time with git and npm enabled, but with a forced version passed in, read from the current `lerna.json`. This will then commit everything to GitHub and push to npm.

Rather than sprinkling some of the build steps in `package.json`'s `scripts` and others in `gulp`, I moved everything `lerna`-related over to `gulp`. This required a light refactoring of the CI configuration.

This is all working for me without `--concurrency=1`, so I'm hoping we can move ahead with that and speed up `lerna` in general.