### PR TITLE
Dev + prod logging

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -91,11 +91,6 @@ function isArrayOfClass(object, expectedClass) {
   }
 }
 
-function isSWEnv() {
-  return ('ServiceWorkerGlobalScope' in self &&
-    self instanceof ServiceWorkerGlobalScope);
-}
-
 function isValue(object, expectedValue) {
   const parameter = Object.keys(object).pop();
   const actualValue = object[parameter];
@@ -132,7 +127,6 @@ export default {
   isInstance,
   isOneOf,
   isType,
-  isSWEnv,
   isValue,
   isArrayOfType,
   isArrayOfClass,

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,0 +1,57 @@
+/*
+ Copyright 2016 Google Inc. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/**
+ * @private
+ * @return {boolean} True, if we're running in the service worker global scope.
+ * False otherwise.
+ */
+function isServiceWorkerGlobalScope() {
+  return ('ServiceWorkerGlobalScope' in self &&
+          self instanceof ServiceWorkerGlobalScope);
+}
+
+/**
+ * @private
+ * @return {boolean} True, if we're running a development bundle.
+ * False otherwise.
+ */
+function isDevBuild() {
+  // The string `BUILD_TARGET` will be replaced during the build process.
+  return `BUILD_TARGET` === `dev`;
+}
+
+/**
+ * @private
+ * @return {boolean} True, if we're running on localhost or the equivalent IP
+ * address. False otherwise.
+ */
+function isLocalhost() {
+  return Boolean(
+    location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    location.hostname === '[::1]' ||
+    // 127.0.0.1/8 is considered localhost for IPv4.
+    location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+    )
+  );
+}
+
+export default {
+  isDevBuild,
+  isLocalhost,
+  isServiceWorkerGlobalScope,
+};

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -29,8 +29,8 @@ function isServiceWorkerGlobalScope() {
  * False otherwise.
  */
 function isDevBuild() {
-  // The string `BUILD_TARGET` will be replaced during the build process.
-  return `BUILD_TARGET` === `dev`;
+  // `BUILD_PROCESS_REPLACE::BUILD_TARGET` is replaced during the build process.
+  return `BUILD_PROCESS_REPLACE::BUILD_TARGET` === `dev`;
 }
 
 /**

--- a/lib/log-helper.js
+++ b/lib/log-helper.js
@@ -16,6 +16,7 @@
 /* eslint-disable no-console */
 
 import LogGroup from './log-group';
+import environment from './environment';
 
 self.goog = self.goog || {};
 self.goog.LOG_LEVEL = self.goog.LOG_LEVEL || {
@@ -50,8 +51,9 @@ class LogHelper {
    * LogHelper constructor.
    */
   constructor() {
-    this._defaultLogLevel = location.hostname === 'localhost' ?
-      self.goog.LOG_LEVEL.debug : self.goog.LOG_LEVEL.none;
+    this._defaultLogLevel = environment.isDevBuild() ?
+      self.goog.LOG_LEVEL.debug :
+      self.goog.LOG_LEVEL.warn;
   }
 
   /**

--- a/packages/sw-background-sync-queue/build.js
+++ b/packages/sw-background-sync-queue/build.js
@@ -42,7 +42,7 @@ const testBuildConfigs = libFiles.reduce((configs, libFile) => {
       iife: path.join('build', 'test', path.basename(libFile)),
     },
     baseDir: __dirname,
-    minify: false,
+    shouldBuildProd: false,
     entry: libFile,
     moduleName,
   }));

--- a/packages/sw-lib/src/index.js
+++ b/packages/sw-lib/src/index.js
@@ -15,14 +15,7 @@
 
 /* eslint-env browser */
 
-import ErrorFactory from './lib/error-factory';
 import SWLib from './lib/sw-lib';
-import assert from '../../../lib/assert.js';
-
-if (!assert.isSWEnv()) {
-  // We are not running in a service worker, print error message
-  throw ErrorFactory.createError('not-in-sw');
-}
 
 /**
  * # sw-lib

--- a/packages/sw-lib/src/lib/sw-lib.js
+++ b/packages/sw-lib/src/lib/sw-lib.js
@@ -67,22 +67,18 @@ class SWLib {
         logHelper.debug({
           message: 'Welcome to Workbox!',
           data: {
-            '📖': 'https://googlechrome.github.io/sw-helpers/',
-            '❓': 'https://stackoverflow.com/questions/ask?tags=workbox',
-            '🐛': 'https://github.com/GoogleChrome/sw-helpers/issues/new',
+            '📖': 'Read the guides and documentation\n' +
+              'https://googlechrome.github.io/sw-helpers/',
+            '❓': 'Use the [workbox] tag on StackOverflow to ask questions\n' +
+              'https://stackoverflow.com/questions/ask?tags=workbox',
+            '🐛': 'Found a bug? Report it on GitHub\n' +
+              'https://github.com/GoogleChrome/sw-helpers/issues/new',
           },
         });
       } else {
         // If this is a dev bundle not on localhost, recommend the prod bundle.
         logHelper.warn(`This appears to be a production server. Please switch
           to the smaller, optimized production build of Workbox.`);
-      }
-    } else {
-      // If this is a prod bundle on localhost, recommend the dev bundle.
-      if (environment.isLocalhost()) {
-        logHelper.warn(`This appears to be a development server. Additional
-          logging and runtime assertions are available by switching to a
-          development build of Workbox.`);
       }
     }
 

--- a/packages/sw-offline-google-analytics/build.js
+++ b/packages/sw-offline-google-analytics/build.js
@@ -44,7 +44,7 @@ const testBuildConfigs = libFiles.reduce((configs, libFile) => {
       iife: path.join('build', 'test', path.basename(libFile)),
     },
     baseDir: __dirname,
-    minify: false,
+    shouldBuildProd: false,
     entry: libFile,
     moduleName,
   }));

--- a/packages/sw-precaching/src/index.js
+++ b/packages/sw-precaching/src/index.js
@@ -69,9 +69,9 @@ import RevisionedCacheManager from
 import UnrevisionedCacheManager from
   './lib/controllers/unrevisioned-cache-manager.js';
 
-import assert from '../../../lib/assert.js';
+import environment from '../../../lib/environment.js';
 
-if (!assert.isSWEnv()) {
+if (!environment.isServiceWorkerGlobalScope()) {
   // We are not running in a service worker, print error message
   throw ErrorFactory.createError('not-in-sw');
 }

--- a/utils/build.js
+++ b/utils/build.js
@@ -147,11 +147,11 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName,
   ];
 
   const devReplacePlugin = replace({
-    '`BUILD_TARGET`': '`dev`',
+    '`BUILD_PROCESS_REPLACE::BUILD_TARGET`': '`dev`',
   });
 
   const prodReplacePlugin = replace({
-    '`BUILD_TARGET`': '`prod`',
+    '`BUILD_PROCESS_REPLACE::BUILD_TARGET`': '`prod`',
     'error-stack-parser': './error-stack-parser-no-op',
   });
 

--- a/utils/build.js
+++ b/utils/build.js
@@ -127,28 +127,15 @@ function buildJSBundle(options) {
  * ('iife', 'es', etc.) to the path to use for the output.
  * @param {String} input.baseDir The path of the project directory.
  * @param {String} input.moduleName The name of the module, for the iife output.
- * @param {boolean} [input.minify] Whether or not we should also build
- * minified output. Defaults to true.
+ * @param {boolean} [input.shouldBuildProd] Whether or not we should also build
+ * a production bundle. Defaults to true.
  * @param {String} [input.entry] Used to override the default entry value of
  * `${baseDir}/src/index.js`.
  * @returns {Array.<Object>}
  */
-function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
-                                entry}) {
+function generateBuildConfigs({formatToPath, baseDir, moduleName,
+                               entry, shouldBuildProd=true}) {
   const buildConfigs = [];
-
-  const babelPlugin = babel({
-    presets: [['babili', {
-      comments: false,
-    }]],
-  });
-
-  // This will replace the usage of the (somewhat large) error-stack-parser
-  // module with a no-op module that has the same interface. It sacrifices some
-  // debugging info in exchange for a smaller minimized bundle.
-  const replacePlugin = replace({
-    'error-stack-parser': './error-stack-parser-no-op',
-  });
 
   const basePlugins = [
     resolve({
@@ -159,11 +146,26 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
     commonjs(),
   ];
 
+  const devReplacePlugin = replace({
+    '`BUILD_TARGET`': '`dev`',
+  });
+
+  const prodReplacePlugin = replace({
+    '`BUILD_TARGET`': '`prod`',
+    'error-stack-parser': './error-stack-parser-no-op',
+  });
+
+  const babelPlugin = babel({
+    presets: [['babili', {
+      comments: false,
+    }]],
+  });
+
   for (let format of Object.keys(formatToPath)) {
     buildConfigs.push({
       rollupConfig: {
         entry: entry || path.join(baseDir, 'src', 'index.js'),
-        plugins: basePlugins,
+        plugins: [devReplacePlugin, ...basePlugins],
       },
       writeConfig: {
         banner: LICENSE_HEADER,
@@ -175,11 +177,11 @@ function generateBuildConfigs({formatToPath, baseDir, moduleName, minify=true,
       },
     });
 
-    if (minify) {
+    if (shouldBuildProd) {
       buildConfigs.push({
         rollupConfig: {
           entry: entry || path.join(baseDir, 'src', 'index.js'),
-          plugins: [replacePlugin, ...basePlugins, babelPlugin],
+          plugins: [prodReplacePlugin, ...basePlugins, babelPlugin],
         },
         writeConfig: {
           banner: LICENSE_HEADER,


### PR DESCRIPTION
R: @addyosmani @gauntface

Fixes #444, fixes #487 

This adds a new `environment.js` module which exposes a few functions to interrogate the current runtime.

It uses the same `rollup-replace-plugin` method we're using elsewhere to determine whether we're in a production or development bundle.

It adds some logging to the `SWLib` constructor based on various combinations of localhost/prod and dev/prod bundles. Here's an example of the output for localhost + dev bundle combo:

<img width="872" alt="screen shot 2017-05-09 at 4 04 52 pm" src="https://cloud.githubusercontent.com/assets/1749548/25870343/c7af5224-34d1-11e7-8624-c2a9a8050af3.png">

Putting startup logging logic into `SWLib`'s constructor seemed like the cleanest approach, since we expect that to be the most typical entry point to the library. Putting the logic into a code path executed by the lower-level, standalone modules seemed like it would just confuse developers who were only using a smaller piece of the framework.