### PR TITLE
Adding checks for dependencies and marking as required

### DIFF
--- a/packages/sw-build-webpack-plugin/package.json
+++ b/packages/sw-build-webpack-plugin/package.json
@@ -24,9 +24,6 @@
   "dependencies": {
     "sw-build": "^0.0.25"
   },
-  "devDependencies": {
-    "fs-extra": "^3.0.1"
-  },
   "author": "Google's Web DevRel Team",
   "license": "Apache-2.0",
   "repository": "googlechrome/sw-helpers",

--- a/packages/sw-build/package.json
+++ b/packages/sw-build/package.json
@@ -27,12 +27,10 @@
   "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-build",
   "dependencies": {
     "chalk": "^1.1.3",
+    "fs-extra": "^3.0.1",
     "glob": "^7.1.1",
     "lodash.template": "^4.4.0",
     "mkdirp": "^0.5.1",
     "sw-lib": "^0.0.25"
-  },
-  "devDependencies": {
-    "fs-extra": "^3.0.1"
   }
 }

--- a/packages/sw-build/test/node/dependency-check.js
+++ b/packages/sw-build/test/node/dependency-check.js
@@ -40,7 +40,7 @@ describe('Test Dependencies', function() {
     // this module itself. So dependencies are checked above and devDependencies
     // can be put in top level.
     const pkg = require('../../package.json');
-    if (pkg.devDependencies && pkg.devDependencies > 0) {
+    if (pkg.devDependencies && Object.keys(pkg.devDependencies) > 0) {
       throw new Error('No devDependencies in this module.');
     }
   });

--- a/packages/sw-build/test/node/dependency-check.js
+++ b/packages/sw-build/test/node/dependency-check.js
@@ -26,11 +26,22 @@ describe('Test Dependencies', function() {
 
       if (Object.keys(unusedDeps.missing).length > 0) {
         console.log(unusedDeps.missing);
-        return reject(new Error('Dependencies missingfrom package.json'));
+        return reject(new Error('Dependencies missing from package.json'));
       }
 
       resolve();
     });
     });
+  });
+
+  it('should have no devDependencies', function() {
+    // This test exists because there have been a number of situations where
+    // dependencies have been used from the top level project and NOT from
+    // this module itself. So dependencies are checked above and devDependencies
+    // can be put in top level.
+    const pkg = require('../../package.json');
+    if (pkg.devDependencies && pkg.devDependencies > 0) {
+      throw new Error('No devDependencies in this module.');
+    }
   });
 });

--- a/packages/sw-cli/package.json
+++ b/packages/sw-cli/package.json
@@ -29,12 +29,10 @@
   "homepage": "https://github.com/GoogleChrome/sw-helpers/tree/master/packages/sw-cli",
   "dependencies": {
     "chalk": "^1.1.3",
+    "fs-extra": "^3.0.1",
     "inquirer": "^2.0.0",
     "meow": "^3.7.0",
     "sw-build": "^0.0.25",
     "update-notifier": "^1.0.3"
-  },
-  "devDependencies": {
-    "fs-extra": "^3.0.1"
   }
 }

--- a/packages/sw-cli/test/node/dependency-check.js
+++ b/packages/sw-cli/test/node/dependency-check.js
@@ -39,7 +39,7 @@ describe('Test Dependencies', function() {
     // this module itself. So dependencies are checked above and devDependencies
     // can be put in top level.
     const pkg = require('../../package.json');
-    if (pkg.devDependencies && pkg.devDependencies > 0) {
+    if (pkg.devDependencies && Object.keys(pkg.devDependencies) > 0) {
       throw new Error('No devDependencies in this module.');
     }
   });

--- a/packages/sw-cli/test/node/dependency-check.js
+++ b/packages/sw-cli/test/node/dependency-check.js
@@ -32,4 +32,15 @@ describe('Test Dependencies', function() {
     });
     });
   });
+
+  it('should have no devDependencies', function() {
+    // This test exists because there have been a number of situations where
+    // dependencies have been used from the top level project and NOT from
+    // this module itself. So dependencies are checked above and devDependencies
+    // can be put in top level.
+    const pkg = require('../../package.json');
+    if (pkg.devDependencies && pkg.devDependencies > 0) {
+      throw new Error('No devDependencies in this module.');
+    }
+  });
 });


### PR DESCRIPTION
R: @jeffposnick @addyosmani

Fixes #527

fs-extra is required but marked as devDep. Added some more tests to dependency checks unit tests to guard against this in the future.
